### PR TITLE
Isolate tags in JSONB to single table

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ A few decisions made in this project:
 * ID column is `osm_id`
 * Default to SRID 3857
 * Default to same units as OpenStreetMap (e.g. km/hr and meters)
-* Extra `tags` stored in `JSONB`
+* Extra `tags` stored in `JSONB` in side table (`osm.tags`)
 * Points, Lines, and Polygons are not mixed in a single table
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,21 @@ For more details on using this project see [Hands on with osm2pgsql's new Flex o
 > Warning - The PgOSM Flex output is currently marked as experimental!  All testing done with osm2pgsql v1.4.0 or later.
 
 
+## Project decisions
+
+A few decisions made in this project:
+
+* ID column is `osm_id`
+* Geometry stored in SRID 3857
+* Default to same units as OpenStreetMap (e.g. km/hr, meters)
+* Data not deemed worthy of a dedicated column goes in side table `osm.tags`. Raw key/value data stored in `JSONB` column
+* Points, Lines, and Polygons are not mixed in a single table
+
+
 
 ## Load main tables
 
-The list of "main" tables will continue to grow.  This will evolve as more layers are added.
+The list of main tables in PgOSM-Flex will continue to grow.
 The only layer intentionally excluded from the `run-all` script is `unitable.lua`.
 
 ```bash
@@ -30,6 +41,28 @@ Run matching SQL scripts.
 
 ```bash
 psql -d pgosm -f ./run-all.sql
+```
+
+
+## Load main tables, No Tags
+
+The `run-no-tags.lua` and `.sql` scripts run the same loads as the `run-all`,
+just skipping the `osm.tags` table.  The `tags` table contains all OSM key/value
+pairs with their `osm_id`.
+
+
+
+```bash
+osm2pgsql --slim --drop \
+    --output=flex --style=./run-no-tags.lua \
+    -d pgosm \
+    ~/tmp/district-of-columbia-latest.osm.pbf
+```
+
+Matching SQL scripts.
+
+```bash
+psql -d pgosm -f ./run-no-tags.sql
 ```
 
 
@@ -63,16 +96,3 @@ osm2pgsql --slim --drop \
     -d pgosm \
     ~/tmp/district-of-columbia-latest.osm.pbf
 ```
-
-
-
-## Notes
-
-A few decisions made in this project:
-
-* ID column is `osm_id`
-* Default to SRID 3857
-* Default to same units as OpenStreetMap (e.g. km/hr and meters)
-* Extra `tags` stored in `JSONB` in side table (`osm.tags`)
-* Points, Lines, and Polygons are not mixed in a single table
-

--- a/flex-config/all_tags.lua
+++ b/flex-config/all_tags.lua
@@ -1,0 +1,108 @@
+-- Put all OSM tag data into a single table w/out geometry
+local json = require('dkjson')
+
+
+local tags_table = osm2pgsql.define_table{
+    name = "tags",
+    schema = 'osm',
+    -- This will generate a column "osm_id INT8" for the id, and a column
+    -- "osm_type CHAR(1)" for the type of object: N(ode), W(way), R(relation)
+    ids = { type = 'any', id_column = 'osm_id', type_column = 'osm_type' },
+    columns = {
+        { column = 'tags',  type = 'jsonb' },
+    }
+}
+
+-- Helper function to remove some of the tags we usually are not interested in.
+-- Returns true if there are no tags left.
+function clean_tags(tags)
+    tags.odbl = nil
+    tags.created_by = nil
+    tags.source = nil
+    tags['source:ref'] = nil
+
+    return next(tags) == nil
+end
+
+function process(object, geometry_type)
+    if clean_tags(object.tags) then
+        return
+    end
+    tags_table:add_row({
+        tags = json.encode(object.tags)
+    })
+end
+
+function all_tags_process_node(object)
+    process(object, 'point')
+end
+
+function all_tags_process_way(object)
+    process(object, 'line')
+end
+
+function all_tags_process_relation(object)
+    if clean_tags(object.tags) then
+        return
+    end
+
+    if object.tags.type == 'multipolygon' or object.tags.type == 'boundary' then
+        tags_table:add_row({
+            tags = json.encode(object.tags),
+            geom = { create = 'area' }
+        })
+    end
+end
+
+
+
+-- deep_copy based on copy2: https://gist.github.com/tylerneylon/81333721109155b2d244
+function deep_copy(obj)
+    if type(obj) ~= 'table' then return obj end
+    local res = setmetatable({}, getmetatable(obj))
+    for k, v in pairs(obj) do res[deep_copy(k)] = deep_copy(v) end
+    return res
+end
+
+
+if osm2pgsql.process_node == nil then
+    -- Change function name here
+    osm2pgsql.process_node = all_tags_process_node
+else
+    local nested = osm2pgsql.process_node
+    osm2pgsql.process_node = function(object)
+        local object_copy = deep_copy(object)
+        nested(object)
+        -- Change function name here
+        all_tags_process_node(object_copy)
+    end
+end
+
+
+if osm2pgsql.process_way == nil then
+    -- Change function name here
+    osm2pgsql.process_way = all_tags_process_way
+else
+    local nested = osm2pgsql.process_way
+    osm2pgsql.process_way = function(object)
+        local object_copy = deep_copy(object)
+        nested(object)
+        -- Change function name here
+        all_tags_process_way(object_copy)
+    end
+end
+
+
+
+if osm2pgsql.process_relation == nil then
+    -- Change function name here
+    osm2pgsql.process_relation = all_tags_process_relation
+else
+    local nested = osm2pgsql.process_relation
+    osm2pgsql.process_relation = function(object)
+        local object_copy = deep_copy(object)
+        nested(object)
+        -- Change function name here
+        all_tags_process_relation(object_copy)
+    end
+end

--- a/flex-config/all_tags.sql
+++ b/flex-config/all_tags.sql
@@ -1,0 +1,6 @@
+COMMENT ON TABLE osm.tags IS 'OpenStreetMap tag data for all OpenStreetMap objects.  tags column in JSONB.';
+
+ALTER TABLE osm.tags
+    ADD CONSTRAINT pk_osm_tags_osm_id
+    PRIMARY KEY (osm_id)
+;

--- a/flex-config/building.lua
+++ b/flex-config/building.lua
@@ -4,9 +4,6 @@
 -- marked with:  "Change function name here"
 --
 
--- Use JSON encoder
-local json = require('dkjson')
-
 -- Change SRID if desired
 local srid = 3857
 
@@ -26,20 +23,9 @@ tables.buildings = osm2pgsql.define_table({
         { column = 'city',     type = 'text' },
         { column = 'state', type = 'text'},
         { column = 'wheelchair', type = 'bool'},
-        { column = 'tags',     type = 'jsonb' },
         { column = 'geom',     type = 'multipolygon', projection = srid},
     }
 })
-
-
-function clean_tags(tags)
-    tags.odbl = nil
-    tags.created_by = nil
-    tags.source = nil
-    tags['source:ref'] = nil
-
-    return next(tags) == nil
-end
 
 
 
@@ -77,8 +63,6 @@ function building_process_way(object)
         return
     end
 
-    clean_tags(object.tags)
-
     -- Using grab_tag() removes from remaining key/value saved to Pg
     local osm_type = object:grab_tag('building')
     local name = object:grab_tag('name')
@@ -92,7 +76,6 @@ function building_process_way(object)
     local operator  = object:grab_tag('operator')
 
     tables.buildings:add_row({
-        tags = json.encode(object.tags),
         osm_type = osm_type,
         name = name,
         housenumber = housenumber,

--- a/flex-config/road.lua
+++ b/flex-config/road.lua
@@ -1,6 +1,3 @@
--- Use JSON encoder
-local json = require('dkjson')
-
 -- Change SRID if desired
 local srid = 3857
 
@@ -13,21 +10,10 @@ tables.highways = osm2pgsql.define_way_table('road_line',
         { column = 'ref',     type = 'text' },
         { column = 'maxspeed', type = 'int' },
         { column = 'oneway',     type = 'direction' },
-        { column = 'tags',     type = 'jsonb' },
         { column = 'geom',     type = 'linestring', projection = srid },
     },
     { schema = 'osm' }
 )
-
-
-function clean_tags(tags)
-    tags.odbl = nil
-    tags.created_by = nil
-    tags.source = nil
-    tags['source:ref'] = nil
-
-    return next(tags) == nil
-end
 
 
 -- Parse a maxspeed value like "30" or "55 mph" and return a number in km/h
@@ -63,8 +49,6 @@ function road_process_way(object)
         return
     end
 
-    clean_tags(object.tags)
-
     -- Using grab_tag() removes from remaining key/value saved to Pg
     local name = object:grab_tag('name')
     local osm_type = object:grab_tag('highway')
@@ -75,7 +59,6 @@ function road_process_way(object)
     oneway = object:grab_tag('oneway') or 0
 
     tables.highways:add_row({
-        tags = json.encode(object.tags),
         name = name,
         osm_type = osm_type,
         ref = ref,

--- a/flex-config/road_major.lua
+++ b/flex-config/road_major.lua
@@ -1,6 +1,3 @@
--- Use JSON encoder
-local json = require('dkjson')
-
 -- Change SRID if desired
 local srid = 3857
 
@@ -15,20 +12,9 @@ tables.road_major = osm2pgsql.define_table({
         { column = 'name',     type = 'text' },
         { column = 'ref',     type = 'text' },
         { column = 'maxspeed', type = 'int' },
-        { column = 'tags',     type = 'jsonb' },
         { column = 'geom',     type = 'linestring', projection = srid },
     }
 })
-
-
-function clean_tags(tags)
-    tags.odbl = nil
-    tags.created_by = nil
-    tags.source = nil
-    tags['source:ref'] = nil
-
-    return next(tags) == nil
-end
 
 
 -- Parse a maxspeed value like "30" or "55 mph" and return a number in km/h
@@ -79,8 +65,6 @@ function road_major_process_way(object)
         return
     end
 
-    clean_tags(object.tags)
-
     -- Using grab_tag() removes from remaining key/value saved to Pg
     local name = object:grab_tag('name')
     local osm_type = object:grab_tag('highway')
@@ -89,7 +73,6 @@ function road_major_process_way(object)
     maxspeed = parse_speed(object.tags.maxspeed)
 
     tables.road_major:add_row({
-        tags = json.encode(object.tags),
         name = name,
         osm_type = osm_type,
         ref = ref,

--- a/flex-config/run-all.lua
+++ b/flex-config/run-all.lua
@@ -1,3 +1,4 @@
+require "all_tags"
 require "road"
 require "road_major"
 require "building"

--- a/flex-config/run-all.lua
+++ b/flex-config/run-all.lua
@@ -1,7 +1,2 @@
 require "all_tags"
-require "road"
-require "road_major"
-require "building"
-require "natural"
-require "traffic"
-require "place"
+require "run-no-tags"

--- a/flex-config/run-all.sql
+++ b/flex-config/run-all.sql
@@ -1,7 +1,2 @@
 \i all_tags.sql
-\i road.sql
-\i road_major.sql
-\i building.sql
-\i natural.sql
-\i traffic.sql
-\i place.sql
+\i run-no-tags.sql

--- a/flex-config/run-all.sql
+++ b/flex-config/run-all.sql
@@ -1,3 +1,4 @@
+\i all_tags.sql
 \i road.sql
 \i road_major.sql
 \i building.sql

--- a/flex-config/run-no-tags.lua
+++ b/flex-config/run-no-tags.lua
@@ -1,0 +1,6 @@
+require "road"
+require "road_major"
+require "building"
+require "natural"
+require "traffic"
+require "place"

--- a/flex-config/run-no-tags.sql
+++ b/flex-config/run-no-tags.sql
@@ -1,0 +1,6 @@
+\i road.sql
+\i road_major.sql
+\i building.sql
+\i natural.sql
+\i traffic.sql
+\i place.sql

--- a/flex-config/traffic.lua
+++ b/flex-config/traffic.lua
@@ -1,6 +1,3 @@
--- Use JSON encoder
-local json = require('dkjson')
-
 -- Change SRID if desired
 local srid = 3857
 
@@ -13,7 +10,6 @@ tables.traffic_point = osm2pgsql.define_table({
     ids = { type = 'node', id_column = 'osm_id' },
     columns = {
         { column = 'osm_type',     type = 'text', not_null = true },
-        { column = 'tags',     type = 'jsonb' },
         { column = 'geom',     type = 'point' , projection = srid},
     }
 })
@@ -45,15 +41,6 @@ tables.traffic_polygon = osm2pgsql.define_table({
 })
 --]]
 
-function clean_tags(tags)
-    tags.odbl = nil
-    tags.created_by = nil
-    tags.source = nil
-    tags['source:ref'] = nil
-
-    return next(tags) == nil
-end
-
 -- Change function name here
 function traffic_process_node(object)
     if not object.tags.highway and not object.tags.railway and not
@@ -61,8 +48,6 @@ function traffic_process_node(object)
             object.tags.amenity then
         return
     end
-
-    clean_tags(object.tags)
 
     if object.tags.highway == 'traffic_signals'
             or object.tags.highway == 'mini_roundabout'
@@ -78,7 +63,6 @@ function traffic_process_node(object)
         local osm_type = object:grab_tag('highway')
 
         tables.traffic_point:add_row({
-            tags = json.encode(object.tags),
             osm_type = osm_type,
             geom = { create = 'point' }
         })
@@ -87,7 +71,6 @@ function traffic_process_node(object)
         local osm_type = 'crossing'
 
         tables.traffic_point:add_row({
-            tags = json.encode(object.tags),
             osm_type = osm_type,
             geom = { create = 'point' }
         })
@@ -96,7 +79,6 @@ function traffic_process_node(object)
         local osm_type = object:grab_tag('barrier')
 
         tables.traffic_point:add_row({
-            tags = json.encode(object.tags),
             osm_type = osm_type,
             geom = { create = 'point' }
         })
@@ -105,7 +87,6 @@ function traffic_process_node(object)
         local osm_type = object:grab_tag('traffic_calming')
 
         tables.traffic_point:add_row({
-            tags = json.encode(object.tags),
             osm_type = osm_type,
             geom = { create = 'point' }
         })
@@ -117,7 +98,6 @@ function traffic_process_node(object)
         local osm_type = object:grab_tag('amenity')
 
         tables.traffic_point:add_row({
-            tags = json.encode(object.tags),
             osm_type = osm_type,
             geom = { create = 'point' }
         })

--- a/flex-config/unitable.lua
+++ b/flex-config/unitable.lua
@@ -1,5 +1,5 @@
 -- Converted from https://github.com/openstreetmap/osm2pgsql/blob/master/flex-config/unitable.lua
---   to use JSONB instead of HSTORE
+--   to use JSONB instead of HSTORE and osm schema.
 
 -- Put all OSM data into a single table
 local json = require('dkjson')


### PR DESCRIPTION
Creating `osm.tags` table with `osm_id` along with `osm_type` and `tags`.  Remove JSON tags processing from individual feature tables.

#### Benefits

* Quick test showed building polygon table reduced by 25% size on disk.  Assumption is most tables will see noticeable reduction in size, some more and some less.
* Removes need for each Lua script to have its own `clean_tags()` function. 
* Tags will have all values in their raw forms, including values cleaned and stored in main feature tables.  Benefit - Allows verifying values stored in feature tables against their raw form.  Can help catch issues in columns that have cleaning applied.  E.g. `maxspeed` and `height` columns often remove units defined in text and convert to OSM defaults.  
* Creates a single place to enable/disable use of JSONB tags

#### Downsides

* Tags will have all values in their raw forms, including values cleaned and stored in main feature tables.  Downside - wastes some disk space by duplication key/value data in feature table.
* Using tags data requires join to `osm.tags`.
