### PR TITLE
Add generated column to provide link to OpenStreetMap.org

### DIFF
--- a/flex-config/all_tags.sql
+++ b/flex-config/all_tags.sql
@@ -5,3 +5,16 @@ ALTER TABLE osm.tags
     ADD CONSTRAINT pk_osm_tags_osm_id_type
     PRIMARY KEY (osm_id, geom_type)
 ;
+
+ALTER TABLE osm.tags
+    ADD osm_url TEXT NOT NULL
+    GENERATED ALWAYS AS (
+        'https://www.openstreetmap.org/'
+            || CASE WHEN geom_type = 'N' THEN 'node'
+                WHEN geom_TYPE = 'W' THEN 'way'
+                ELSE 'relation'
+                END
+            || '/' || osm_id::TEXT
+        )
+    STORED
+;


### PR DESCRIPTION
Starting with adding the `osm_url` column on the `osm.tags` table.  I think adding this to every table might be helpful, need to look at costs of doing so on larger data sources first.