### PR TITLE
Improve nested polygon handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ small areas (Colorado), takes significantly longer on larger areas (North Americ
 CALL osm.build_nested_admin_polygons();
 ```
 
+The above can take a long time.  Monitor progress with this query.
+
+```sql
+SELECT COUNT(*) AS row_count,
+        COUNT(*) FILTER (WHERE nest_level IS NOT NULL) AS nesting_set
+    FROM osm.place_polygon_nested
+;
+```
+
 
 
 ## One table to rule them all

--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ osm2pgsql --slim --drop \
 psql -d pgosm -f ./road_major.sql
 ```
 
+## Nested admin polygons
+
+This is defined in `flex-config/place.sql` but not ran.  Can run quickly on
+small areas (Colorado), takes significantly longer on larger areas (North America).
+
+```sql
+CALL osm.build_nested_admin_polygons();
+```
+
+
 
 ## One table to rule them all
 


### PR DESCRIPTION
Original method worked well on small regions (e.g. Colorado).  Larger regions like U.S. suffered from long single-threaded load w/ no way to monitor progress or guesstimate completion.  New method defines procedure that loops through in variable-sized batches.  Makes it easy to cancel running without losing progress on processing.

Will work up improved usage examples in near future.

Progresses #37.