### PR TITLE
Relations missing from tags and unitable

### DIFF
--- a/QUERY.md
+++ b/QUERY.md
@@ -65,9 +65,9 @@ SELECT COUNT(*) AS row_count,
 
 
 
-## Quality Control Queries
+# Quality Control Queries
 
-### Features not Loaded
+## Features not Loaded
 
 The process of selectively load specific features and not others always has the chance
 of accidentally missing important data.
@@ -118,4 +118,19 @@ SELECT * FROM osm.road_line
 ;
 ```
 > Not all rows returned are errors.  `highway = 'construction'` is not necessarily determinate...
+
+
+## Relations missing from unitable
+
+```sql
+SELECT t.*
+    FROM osm.tags t
+    WHERE t.geom_type = 'R' 
+        AND NOT EXISTS (
+            SELECT 1
+            FROM osm.unitable u
+            WHERE u.geom_type = t.geom_type AND t.osm_id = u.osm_id
+);
+```
+
 

--- a/flex-config/all_tags.lua
+++ b/flex-config/all_tags.lua
@@ -26,7 +26,7 @@ function clean_tags(tags)
     return next(tags) == nil
 end
 
-function process(object, geometry_type)
+function process(object)
     if clean_tags(object.tags) then
         return
     end
@@ -36,24 +36,15 @@ function process(object, geometry_type)
 end
 
 function all_tags_process_node(object)
-    process(object, 'point')
+    process(object)
 end
 
 function all_tags_process_way(object)
-    process(object, 'line')
+    process(object)
 end
 
 function all_tags_process_relation(object)
-    if clean_tags(object.tags) then
-        return
-    end
-
-    if object.tags.type == 'multipolygon' or object.tags.type == 'boundary' then
-        tags_table:add_row({
-            tags = json.encode(object.tags),
-            geom = { create = 'area' }
-        })
-    end
+    process(object)
 end
 
 

--- a/flex-config/unitable.lua
+++ b/flex-config/unitable.lua
@@ -55,16 +55,31 @@ function osm2pgsql.process_way(object)
     process(object, 'line')
 end
 
+-- Main relation types from https://wiki.openstreetmap.org/wiki/Types_of_relation
 function osm2pgsql.process_relation(object)
     if clean_tags(object.tags) then
         return
     end
 
-    if object.tags.type == 'multipolygon' or object.tags.type == 'boundary' then
+    if (object.tags.type == 'multipolygon'
+            or object.tags.type == 'boundary')
+            then
         dtable:add_row({
             tags = json.encode(object.tags),
             geom = { create = 'area' }
         })
+    elseif (object.tags.type == 'route'
+            or object.tags.type == 'route_master'
+            or object.tags.type == 'public_transport'
+            or object.tags.type == 'waterway')
+            then
+        dtable:add_row({
+            tags = json.encode(object.tags),
+            geom = { create = 'line' }
+        })
+
     end
+
+
 end
 


### PR DESCRIPTION
Was looking into the impact of #2.  Found `osm.tags` and `osm.unitable` were both missing major portions of the total relations. Easy to all all to tags, less easy adding all to `unitable` due to handling geometry types.  

Example OSM IDs of relations:

* `161644`
* `62152`
* `416064`

Query to find relations missing from `unitable`.

```sql
SELECT t.*
    FROM osm.tags t
    WHERE t.geom_type = 'R' 
        AND NOT EXISTS (
            SELECT 1
            FROM osm.unitable u
            WHERE u.geom_type = t.geom_type AND t.osm_id = u.osm_id
);
    
```