### PR TITLE
Improve building layer - Addresses, Offices and columns

### DIFF
--- a/flex-config/helpers.lua
+++ b/flex-config/helpers.lua
@@ -161,12 +161,12 @@ function major_road(highway)
     end
 
 -- From https://github.com/openstreetmap/osm2pgsql/blob/master/flex-config/places.lua
-local function starts_with(str, start)
+function starts_with(str, start)
    return str:sub(1, #start) == start
 end
 
 -- From http://lua-users.org/wiki/StringRecipes
-local function ends_with(str, ending)
+function ends_with(str, ending)
    return ending == "" or str:sub(-#ending) == ending
 end
 

--- a/flex-config/sql/building.sql
+++ b/flex-config/sql/building.sql
@@ -41,12 +41,14 @@ CREATE INDEX ix_osm_building_polygon_type ON osm.building_polygon (osm_type);
 
 
 CREATE VIEW osm.vbuilding_all AS
-SELECT osm_id, 'N' AS geom_type, osm_type, name, levels, height, operator, wheelchair,
-        address, geom
+SELECT osm_id, 'N' AS geom_type, osm_type, osm_subtype, name, levels,
+		height, operator, wheelchair, address,
+		geom
     FROM osm.building_point
 UNION
-SELECT osm_id, 'W' AS geom_type, osm_type, name, levels, height, operator, wheelchair,
-        address, ST_Centroid(geom) AS geom
+SELECT osm_id, 'W' AS geom_type, osm_type, osm_subtype, name, levels,
+		height, operator, wheelchair, address,
+		ST_Centroid(geom) AS geom
     FROM osm.building_polygon
 ;
 
@@ -68,6 +70,10 @@ COMMENT ON COLUMN osm.building_point.address IS 'Address combined from address p
 COMMENT ON COLUMN osm.building_polygon.address IS 'Address combined from address parts in helpers.get_address().';
 
 
-COMMENT ON COLUMN osm.building_point.osm_type IS 'Value from "building" tag if it exists, "building_part" if building:part exists, "address" if an address existed with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';
-COMMENT ON COLUMN osm.building_polygon.osm_type IS 'Value from "building" tag if it exists, "building_part" if building:part exists, "address" if an address existed with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';
-COMMENT ON COLUMN osm.vbuilding_all.osm_type IS 'Value from "building" tag if it exists, "building_part" if building:part exists, "address" if an address existed with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';
+COMMENT ON COLUMN osm.building_point.osm_type IS 'Values: building, building_part, office or address. All but address described in osm_subtype.  Value is address if addr:* tags exist with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';
+COMMENT ON COLUMN osm.building_polygon.osm_type IS 'Values: building, building_part, office or address. All but address described in osm_subtype.  Value is address if addr:* tags exist with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';
+COMMENT ON COLUMN osm.vbuilding_all.osm_type IS 'Values: building, building_part, office or address. All but address described in osm_subtype.  Value is address if addr:* tags exist with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';
+
+COMMENT ON COLUMN osm.building_point.osm_subtype IS 'Further describes osm_type for building, building_part, and office.';
+COMMENT ON COLUMN osm.building_polygon.osm_subtype IS 'Further describes osm_type for building, building_part, and office.';
+COMMENT ON COLUMN osm.vbuilding_all.osm_subtype IS 'Further describes osm_type for building, building_part, and office.';

--- a/flex-config/sql/building.sql
+++ b/flex-config/sql/building.sql
@@ -41,11 +41,11 @@ CREATE INDEX ix_osm_building_polygon_type ON osm.building_polygon (osm_type);
 
 
 CREATE VIEW osm.vbuilding_all AS
-SELECT osm_id, 'N' AS geom_type, name, levels, height, operator, wheelchair,
+SELECT osm_id, 'N' AS geom_type, osm_type, name, levels, height, operator, wheelchair,
         address, geom
     FROM osm.building_point
 UNION
-SELECT osm_id, 'W' AS geom_type, name, levels, height, operator, wheelchair,
+SELECT osm_id, 'W' AS geom_type, osm_type, name, levels, height, operator, wheelchair,
         address, ST_Centroid(geom) AS geom
     FROM osm.building_polygon
 ;
@@ -66,3 +66,8 @@ COMMENT ON COLUMN osm.vbuilding_all.operator IS 'Entity in charge of operations.
 
 COMMENT ON COLUMN osm.building_point.address IS 'Address combined from address parts in helpers.get_address().';
 COMMENT ON COLUMN osm.building_polygon.address IS 'Address combined from address parts in helpers.get_address().';
+
+
+COMMENT ON COLUMN osm.building_point.osm_type IS 'Value from "building" tag if it exists, "building_part" if building:part exists, "address" if an address existed with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';
+COMMENT ON COLUMN osm.building_polygon.osm_type IS 'Value from "building" tag if it exists, "building_part" if building:part exists, "address" if an address existed with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';
+COMMENT ON COLUMN osm.vbuilding_all.osm_type IS 'Value from "building" tag if it exists, "building_part" if building:part exists, "address" if an address existed with no other major keys to group it in a more specific layer.  See address_only_building() in building.lua';


### PR DESCRIPTION
Addresses #98 and #97.  Other improvements are being found in the process. :+1:

----

Initial testing shows this adds new building records in the DC sub-region such as this:  https://www.openstreetmap.org/way/66346595

Seems to be a good addition.  For this particular building it appears potentially `office=*` needs to be considered a building by default too.

Idea of # of records affected:

```sql
SELECT COUNT(*),
        COUNT(*) FILTER (WHERE b.osm_type = 'address') AS address_record,
        COUNT(*) FILTER (WHERE b.osm_type != 'address') AS building_tag_exists
    FROM osm.vbuilding_all b
    INNER JOIN osm.tags t ON b.osm_id = t.osm_id AND b.geom_type = t.geom_type
;
```
```bash
count |address_record|building_tag_exists|
------|--------------|-------------------|
178647|         17000|             161647|
```

Needs more review on what other tags are on the `osm_type = 'address'` records.  Likely still other overlap that should be removed, and also other improvements (explicit inclusions) that should be considered.

```sql
SELECT t.osm_url, t.tags, *
    FROM osm.vbuilding_all b
    INNER JOIN osm.tags t ON b.osm_id = t.osm_id AND b.geom_type = t.geom_type
    WHERE b.osm_type = 'address'
;
```
