### PR TITLE
Update Docker process to use dynamic osm2pgsql command via API

### DIFF
--- a/DOCKER-RUN.md
+++ b/DOCKER-RUN.md
@@ -27,7 +27,29 @@ docker run --name pgosm -d \
     -p 5433:5432 -d rustprooflabs/pgosm-flex
 ```
 
-## Run and Customize PgOSM-Flex
+## Run PgOSM-Flex
+
+The following `docker exec` command runs PgOSM Flex to load the District of Columbia
+region
+
+The command  `bash docker/run_pgosm_flex.sh` runs the full process. The
+script uses a region (`north-america/us`) and sub-region (`district-of-columbia`)
+that must match values in URLs from the Geofabrik download server.
+The 3rd parameter tells the script the server has 8 GB RAM available for osm2pgsql, Postgres, and the OS.  The PgOSM-Flex layer set is defined (`run-all`).
+
+
+```bash
+docker exec -it \
+    -e POSTGRES_PASSWORD=mysecretpassword -e POSTGRES_USER=postgres \
+    pgosm bash docker/run_pgosm_flex.sh \
+    north-america/us \
+    district-of-columbia \
+    8 \
+    run-all
+```
+
+
+## Customize PgOSM-Flex
 
 The following command sets the four (4) main env vars used to customize PgOSM-Flex.
 
@@ -36,11 +58,6 @@ The following command sets the four (4) main env vars used to customize PgOSM-Fl
 * `PGOSM_DATA_SCHEMA_ONLY` - When `false` (default) the `pgosm` schema is exported along with the `PGOSM_DATA_SCHEMA_NAME` schema
 * `PGOSM_DATE` - Used to document data loaded to DB in `osm.pgosm_flex.pgosm_date`, and for archiving PBF/MD5 files.  Defaults to today.
 * `PGOSM_LANGUAGE` - Used to prefer specific language when it exists.
-
-The command  `bash docker/run_pgosm_flex.sh` runs the full process. The
-script uses a region (`north-america/us`) and sub-region (`district-of-columbia`)
-that must match values in URLs from the Geofabrik download server.
-The osm2pgsql cache is set (`2000`) and the PgOSM-Flex layer set is defined (`run-all`).
 
 
 ```bash
@@ -54,7 +71,7 @@ docker exec -it \
     pgosm bash docker/run_pgosm_flex.sh \
     north-america/us \
     district-of-columbia \
-    500 \
+    8 \
     run-all
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,15 @@ RUN apt-get update \
         libboost-dev libboost-system-dev \
         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
         libbz2-dev libpq-dev libproj-dev lua5.2 liblua5.2-dev \
+        python3 python3-distutils \
+        curl \
     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
+    && python3 /tmp/get-pip.py \
+    && rm /tmp/get-pip.py
+
+RUN pip install requests
 
 
 WORKDIR /tmp
@@ -24,6 +32,7 @@ RUN git clone git://github.com/openstreetmap/osm2pgsql.git \
         libboost-dev libboost-system-dev \
         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
         libbz2-dev libpq-dev libproj-dev \
+        curl \
     && apt autoremove -y \
     && cd /tmp && rm -r /tmp/osm2pgsql
 

--- a/MANUAL-STEPS-RUN.md
+++ b/MANUAL-STEPS-RUN.md
@@ -226,3 +226,30 @@ psql -d $PGOSM_CONN -f ./sql/road_major.sql
 
 
 > WARNING:  Running multiple `osm2pgsql` commands requires processing the source PBF multiple times. This can waste considerable time on larger imports.  Further, attempting to define multiple styles with additional `--style=style.lua` switches results in only the last style being processed.  To mix and match multiple styles, create a custom Lua script similar to `run-all.lua` or `run-no-tags.lua`.
+
+
+
+## Additional structure and helper data
+
+**Optional**
+
+Deploying the additional table structure is done via [sqitch](https://sqitch.org/).
+
+Assumes this repo is cloned under `~/git/pgosm-flex/` and a local Postgres
+DB named `pgosm` has been created with the `postgis` extension installed.
+
+```bash
+cd ~/git/pgosm-flex/db
+sqitch deploy db:pg:pgosm
+```
+
+With the structures created, load helper road data.
+
+```bash
+cd ~/git/pgosm-flex/db
+psql -d pgosm -f data/roads-us.sql
+```
+
+
+Currently only U.S. region drafted, more regions with local `maxspeed` are welcome via PR!
+

--- a/docker/osm2pgsql_recommendation.py
+++ b/docker/osm2pgsql_recommendation.py
@@ -1,0 +1,51 @@
+"""
+
+Usage:
+	python3 osm2pgsql_recommendation.py colorado 8
+"""
+import os
+import sys
+import requests
+
+# Get run-time options
+region_name = sys.argv[1]
+system_ram_gb = sys.argv[2]
+output_path = sys.argv[3]
+pgosm_layer_set = sys.argv[4]
+
+# Always renamed to -latest at runtime for MD5 validation
+#  taking advantage of that here to simplify
+pbf_filename = f'{region_name}-latest'
+
+pbf_file = f'{pbf_filename}.osm.pbf'
+print(pbf_file)
+
+osm_pbf_gb = os.path.getsize(pbf_file) / 1024 / 1024 / 1024	
+
+# PgOSM-Flex currently does not support/test append mode.
+append = False
+
+api_endpoint = 'https://osm2pgsql-tuner.com/api/v1'
+api_endpoint += f'?system_ram_gb={system_ram_gb}'
+api_endpoint += f'&osm_pbf_gb={osm_pbf_gb}'
+api_endpoint += f'&append={append}'
+api_endpoint += f'&pbf_filename={pbf_filename}'
+api_endpoint += f'&pgosm_layer_set={pgosm_layer_set}'
+
+headers = {"User-Agent": 'PgOSM-Flex-Docker'}
+result = requests.get(api_endpoint, headers=headers)
+print(f'Status code: {result.status_code}')
+
+rec = result.json()['osm2pgsql']
+
+osm2pgsql_cmd = rec['cmd']
+osm2pgsql_cmd = osm2pgsql_cmd.replace('~/pgosm-data/', output_path)
+osm2pgsql_cmd = osm2pgsql_cmd.replace('-d $PGOSM_CONN', '-U postgres -d pgosm')
+#print(f"\nCommand:\n{ osm2pgsql_cmd } ")
+
+script_filename = f'osm2pgsql-{region_name}.sh'
+osm2pgsql_script_path = os.path.join(output_path, script_filename)
+
+with open(osm2pgsql_script_path,'w') as out_script:
+	out_script.write(osm2pgsql_cmd)
+

--- a/docker/osm2pgsql_recommendation.py
+++ b/docker/osm2pgsql_recommendation.py
@@ -1,4 +1,5 @@
-"""
+"""Used by PgOSM-Flex Docker image to get osm2pgsql command to run from
+the osm2pgsql-tuner API.
 
 Usage:
 	python3 osm2pgsql_recommendation.py colorado 8
@@ -33,6 +34,7 @@ api_endpoint += f'&pbf_filename={pbf_filename}'
 api_endpoint += f'&pgosm_layer_set={pgosm_layer_set}'
 
 headers = {"User-Agent": 'PgOSM-Flex-Docker'}
+print(f'osm2pgsql-tuner URL w/ parameters: {api_endpoint}')
 result = requests.get(api_endpoint, headers=headers)
 print(f'Status code: {result.status_code}')
 
@@ -41,11 +43,10 @@ rec = result.json()['osm2pgsql']
 osm2pgsql_cmd = rec['cmd']
 osm2pgsql_cmd = osm2pgsql_cmd.replace('~/pgosm-data/', output_path)
 osm2pgsql_cmd = osm2pgsql_cmd.replace('-d $PGOSM_CONN', '-U postgres -d pgosm')
-#print(f"\nCommand:\n{ osm2pgsql_cmd } ")
 
 script_filename = f'osm2pgsql-{region_name}.sh'
 osm2pgsql_script_path = os.path.join(output_path, script_filename)
 
 with open(osm2pgsql_script_path,'w') as out_script:
 	out_script.write(osm2pgsql_cmd)
-
+	out_script.write('\n')

--- a/docker/run_pgosm_flex.sh
+++ b/docker/run_pgosm_flex.sh
@@ -134,8 +134,7 @@ else
     exit 1
 fi
 
-#python3 osm2pgsql_recommendation.py colorado 8 /app/output/ run-road-place
-python3 /app/docker/osm2pgsql_recommendation.py $2 $3 $OUT_PATH $4
+python3 /app/docker/osm2pgsql_recommendation.py $2 $3 $OUT_PATH $4 >> $LOG_FILE
 
 SLEEP_SEC=5
 
@@ -188,23 +187,10 @@ osm2pgsql --version >> $LOG_FILE
 echo "Running osm2pgsql..." >> $LOG_FILE
 cd $FLEX_PATH
 
-# Hard coding for initial testing
-SAFE_MODE=false
+echo 'Using command suggested by osm2pgsql-tuner: ' >> $LOG_FILE
+cat $OUT_PATH/osm2pgsql-$2.sh  >> $LOG_FILE
+bash $OUT_PATH/osm2pgsql-$2.sh &>> $LOG_FILE
 
-if [ $SAFE_MODE == true ]; then
-  # Cache was originally dynamic, now hard coding to osm2pgsql default. 
-  # Maybe not fair, but...?
-  osm2pgsql -U postgres --create --slim --drop \
-    --cache 800 \
-    --output=flex --style=./$4.lua \
-    -d pgosm  $PBF_FILE &>> $LOG_FILE
-else
-  echo 'WARNING - SAFE MODE NOT ENABLED' >> $LOG_FILE
-  echo 'Running command suggested by https://osm2pgsql-tuner.com : '
-  cat $OUT_PATH/osm2pgsql-$2.sh  >> $LOG_FILE
-  echo '\n' >> $LOG_FILE
-  bash $OUT_PATH/osm2pgsql-$2.sh &>> $LOG_FILE
-fi
 
 echo "Running PgOSM-Flex post-processing SQL script: $4.sql" >> $LOG_FILE
 psql -U postgres -d pgosm -f $4.sql >> $LOG_FILE


### PR DESCRIPTION
Closes #129.

Includes a bunch of improvements throughout the README files.  Some changes RE the main topic here; also removing duplication, restructuring to better guide through Docker usage for easy get-started path.