### PR TITLE
Building images on push

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,6 @@
 name: Publish PgOSM-Flex Docker image
 on:
   push:
-    branches:
-      - broken-see-gh132
 jobs:
   push_to_registry:
     name: Push PgOSM-Flex image to Docker Hub
@@ -22,7 +20,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: rustprooflabs/pgosm-flex:latest
+          tags: rustprooflabs/pgosm-flex:ghdev
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 


### PR DESCRIPTION
Should make investigating/fixing #132 easier.  Pushing image tagged as `ghdev` to keep out of the way for prod systems.