### PR TITLE
Stop GH actions from sending to Docker Hub

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ on:
   push:
 jobs:
   push_to_registry:
-    name: Push PgOSM-Flex image to Docker Hub
+    name: Build and inspect PgOSM Flex image
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -16,8 +16,6 @@ jobs:
           load: true
           push: false
           tags: rustprooflabs/pgosm-flex:ghdev
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Inspect image
         run: |
           docker image inspect rustprooflabs/pgosm-flex:ghdev

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,19 +8,16 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - name: Build and Push to Docker Hub
+      - name: Build image for local GH use
         id: docker_build_push
         uses: docker/build-push-action@v2
         with:
-          push: true
+          context: .
+          load: true
+          push: false
           tags: rustprooflabs/pgosm-flex:ghdev
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-
+      - name: Inspect image
+        run: |
+          docker image inspect rustprooflabs/pgosm-flex:ghdev


### PR DESCRIPTION
Using Docker Hub's builder which does not suffer from the problem in #132.  Removing the Push from GH actions to DH.

Plan to keep using GH's actions for testing as pushes coming through, will enhance that in the future.