### PR TITLE
Raise error when PBF file is missing for historic date

### DIFF
--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -417,10 +417,15 @@ def pbf_download_needed(pbf_file_with_date, md5_file_with_date, pgosm_date):
                 print('PBF for today available but not MD5... download needed')
                 download_needed = True
             else:
-                err = 'Missing MD5 file. Cannot validate.'
+                err = f'Missing MD5 file for {pgosm_date}. Cannot validate.'
                 logger.error(err)
                 raise FileNotFoundError(err)
     else:
+        if not pgosm_date == get_today():
+            err = f'Missing PBF file for {pgosm_date}. Cannot proceed.'
+            logger.error(err)
+            raise FileNotFoundError(err)
+
         logger.info('PBF file not found locally. Download required')
         download_needed = True
 


### PR DESCRIPTION
Closes #163.

Example of change in log file.

```bash
2021-08-30 18:06:57,204:ERROR:pgosm-flex:pgosm_flex:Missing PBF file for 2019-01-02. Cannot proceed.
```

At command line, raises `FileNotFoundError`.

```bash
FileNotFoundError: Missing PBF file for 2019-01-02. Cannot proceed.
```