### PR TITLE
Clarify handling of oneway tag and resulting values in Postgres. 

### DIFF
--- a/db/qgis-style/README.md
+++ b/db/qgis-style/README.md
@@ -105,7 +105,7 @@ UPDATE public.layer_styles_staging
 ```
 
 
-```
+```bash
 pg_dump --no-owner --no-privileges --data-only --table=public.layer_styles_staging \
     -d pgosm \
     -f layer_styles.sql

--- a/flex-config/sql/road.sql
+++ b/flex-config/sql/road.sql
@@ -22,8 +22,8 @@ COMMENT ON COLUMN osm.road_point.name IS 'Best name option determined by helpers
 COMMENT ON COLUMN osm.road_line.name IS 'Best name option determined by helpers.get_name(). Keys with priority are: name, short_name, alt_name and loc_name.  See pgosm-flex/flex-config/helpers.lua for full logic of selection.';
 COMMENT ON COLUMN osm.road_point.geom IS 'Geometry loaded by osm2pgsql.';
 COMMENT ON COLUMN osm.road_line.geom IS 'Geometry loaded by osm2pgsql.';
-COMMENT ON COLUMN osm.road_point.oneway IS 'Indicates if travel is one-way only.';
-COMMENT ON COLUMN osm.road_line.oneway IS 'Indicates if travel is one-way only.';
+COMMENT ON COLUMN osm.road_point.oneway IS 'Used for calculating costs for routing with one-way controls.  0 indicates 2-way traffic is allowed (or assumed).  1 indicates travel is allowed forward only, -1 indicates travel is allowed reverse only. Values reversible and alternating result in NULL.  See https://wiki.openstreetmap.org/wiki/Key:oneway';
+COMMENT ON COLUMN osm.road_line.oneway IS 'Used for calculating costs for routing with one-way controls.  0 indicates 2-way traffic is allowed (or assumed).  1 indicates travel is allowed forward only, -1 indicates travel is allowed reverse only. Values reversible and alternating result in NULL.  See https://wiki.openstreetmap.org/wiki/Key:oneway';
 
 COMMENT ON COLUMN osm.road_point.ref IS 'Reference number or code. Best ref option determined by helpers.get_ref(). https://wiki.openstreetmap.org/wiki/Key:ref';
 COMMENT ON COLUMN osm.road_line.ref IS 'Reference number or code. Best ref option determined by helpers.get_ref(). https://wiki.openstreetmap.org/wiki/Key:ref';

--- a/flex-config/style/road.lua
+++ b/flex-config/style/road.lua
@@ -79,11 +79,14 @@ function road_process_node(object)
 
     -- in km/hr
     local maxspeed = parse_speed(object.tags.maxspeed)
-    local oneway = object:grab_tag('oneway') or 0
+
+    -- results in nil for reversible and alternating
+    local oneway = object.tags.oneway or 0
+
     local layer = parse_layer_value(object.tags.layer)
-    local tunnel = object:grab_tag('tunnel')
-    local bridge = object:grab_tag('bridge')
-    local access = object:grab_tag('access')
+    local tunnel = object.tags.tunnel
+    local bridge = object.tags.bridge
+    local access = object.tags.access
 
     tables.road_point:add_row({
         name = name,
@@ -115,12 +118,15 @@ function road_process_way(object)
 
     -- in km/hr
     local maxspeed = parse_speed(object.tags.maxspeed)
-    local oneway = object:grab_tag('oneway') or 0
+
+    -- results in nil for reversible and alternating
+    local oneway = object.tags.oneway or 0
+
     local major = major_road(osm_type)
     local layer = parse_layer_value(object.tags.layer)
-    local tunnel = object:grab_tag('tunnel')
-    local bridge = object:grab_tag('bridge')
-    local access = object:grab_tag('access')
+    local tunnel = object.tags.tunnel
+    local bridge = object.tags.bridge
+    local access = object.tags.access
 
     if object.tags.area == 'yes'
         or object.tags.indoor == 'room'


### PR DESCRIPTION
Progresses #172.

Add comment in Lua code to clarify that nil is expected for specific values from `oneway` tag.

Improve comments in SQL to explain the expected values.