### PR TITLE
Direct file and connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ docker-clean: ## Stops pgosm Docker container and removes local pgosm-data direc
 	rm -rvf pgosm-data|| echo "folder pgosm-data did not exist"
 	# rare race condition: the stoppe dcontainer may be "Removal In Progress"
 	while docker container inspect pgosm >/dev/null 2>&1; do sleep 1; done
+	@docker stop anotherdb > /dev/null 2>&1 && echo "anotherdb container removed"|| echo "anotherdb container not present, nothing to remove"
+
 
 .PHONY: build
 build: ## Builds PgOSM Flex

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,27 @@ CURRENT_GID := $(shell id -g)
 TODAY := $(shell date +'%Y-%m-%d')
 
 .PHONY: all
-all: docker-clean build-run-docker unit-tests
+all:
+	make docker-clean
+	make build
+	make run-with-external-db
+	make docker-clean
+	make run-docker
+	make unit-tests
 
 .PHONY: docker-clean
 docker-clean: ## Stops pgosm Docker container and removes local pgosm-data directory
 	@docker stop pgosm > /dev/null 2>&1 && echo "pgosm container removed"|| echo "pgosm container not present, nothing to remove"
 	rm -rvf pgosm-data|| echo "folder pgosm-data did not exist"
+	# rare race condition: the stoppe dcontainer may be "Removal In Progress"
+	while docker container inspect pgosm >/dev/null 2>&1; do sleep 1; done
 
+.PHONY: build
+build: ## Builds PgOSM Flex
+	docker build -t rustprooflabs/pgosm-flex .
 
 .PHONY: build-run-docker
-build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
-	docker build -t rustprooflabs/pgosm-flex .
+run-docker: ## Runs PgOSM Flex with D.C. test file
 	docker run --name pgosm \
 		--rm \
 		-v $(shell pwd)/pgosm-data:/app/output \
@@ -36,9 +46,6 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		pgosm:/app/output/district-of-columbia-$(TODAY).osm.pbf
 	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf.md5 \
 		pgosm:/app/output/district-of-columbia-$(TODAY).osm.pbf.md5
-	# copy the test data with a meaningless name
-	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf \
-		pgosm:/app/output/some_arbitrary_name.osm.pbf
 
 	# allow files created in later step to be created
 	docker exec -it pgosm \
@@ -57,6 +64,30 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		--region=north-america/us \
 		--subregion=district-of-columbia \
 		--debug
+
+.PHONY: run-with-external-db
+run-with-external-db: ## Runs PgOSM Flex using a specific PBF file and connection string
+
+
+	docker run --name pgosm \
+		--rm \
+		-v $(shell pwd)/pgosm-data:/app/output \
+		-v /etc/localtime:/etc/localtime:ro \
+		-e POSTGRES_PASSWORD=mysecretpassword \
+		-p 5433:5432 \
+		-d \
+		rustprooflabs/pgosm-flex
+	# copy the test data with a meaningless name
+	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf \
+		pgosm:/app/output/some_arbitrary_name.osm.pbf
+
+	# allow files created in later step to be created
+	docker exec -it pgosm \
+		chown $(CURRENT_UID):$(CURRENT_GID) /app/output/
+	# Needed for unit-tests
+	docker exec -it pgosm \
+		chown $(CURRENT_UID):$(CURRENT_GID) /app/docker/
+
 	# process it, this time without providing the region but directly the filename
 	docker exec -it \
 		-e POSTGRES_PASSWORD=mysecretpassword \

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ run-with-external-db: ## Runs PgOSM Flex using a specific PBF file and connectio
 		-e POSTGRES_USER=postgres \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		pgosm python3 docker/pgosm_flex.py  \
-		--layerset=run-all \
+		--layerset=everything \
 		--ram=1 \
 		--input-file=/app/output/some_arbitrary_name.osm.pbf \
 		--conn-str=postgres://postgres:anotherpassword@anotherdb \

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		pgosm:/app/output/district-of-columbia-$(TODAY).osm.pbf
 	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf.md5 \
 		pgosm:/app/output/district-of-columbia-$(TODAY).osm.pbf.md5
+	# copy the test data with a meaningless name
+	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf \
+		pgosm:/app/output/some_arbitrary_name.osm.pbf
 
 	# allow files created in later step to be created
 	docker exec -it pgosm \
@@ -54,7 +57,16 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		--region=north-america/us \
 		--subregion=district-of-columbia \
 		--debug
-
+	# process it, this time without providing the region but directly the filename
+	docker exec -it \
+		-e POSTGRES_PASSWORD=mysecretpassword \
+		-e POSTGRES_USER=postgres \
+		-u $(CURRENT_UID):$(CURRENT_GID) \
+		pgosm python3 docker/pgosm_flex.py  \
+		--layerset=run-all \
+		--ram=1 \
+		--input-file=/app/output/some_arbitrary_name.osm.pbf \
+		--debug
 
 .PHONY: unit-tests
 unit-tests: ## Runs Python unit tests and data import tests

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ run-docker: ## Runs PgOSM Flex with D.C. test file
 
 .PHONY: run-with-external-db
 run-with-external-db: ## Runs PgOSM Flex using a specific PBF file and connection string
-
+	docker run --name anotherdb --rm -e POSTGRES_PASSWORD=anotherpassword -d postgis/postgis
 
 	docker run --name pgosm \
 		--rm \
@@ -75,6 +75,7 @@ run-with-external-db: ## Runs PgOSM Flex using a specific PBF file and connectio
 		-v /etc/localtime:/etc/localtime:ro \
 		-e POSTGRES_PASSWORD=mysecretpassword \
 		-p 5433:5432 \
+		--link anotherdb \
 		-d \
 		rustprooflabs/pgosm-flex
 	# copy the test data with a meaningless name
@@ -89,6 +90,7 @@ run-with-external-db: ## Runs PgOSM Flex using a specific PBF file and connectio
 		chown $(CURRENT_UID):$(CURRENT_GID) /app/docker/
 
 	# process it, this time without providing the region but directly the filename
+	# also use the separate DB instead of the incorporated one
 	docker exec -it \
 		-e POSTGRES_PASSWORD=mysecretpassword \
 		-e POSTGRES_USER=postgres \
@@ -97,6 +99,7 @@ run-with-external-db: ## Runs PgOSM Flex using a specific PBF file and connectio
 		--layerset=run-all \
 		--ram=1 \
 		--input-file=/app/output/some_arbitrary_name.osm.pbf \
+		--conn-str=postgres://postgres:anotherpassword@anotherdb \
 		--debug
 
 .PHONY: unit-tests

--- a/docker/db.py
+++ b/docker/db.py
@@ -377,7 +377,10 @@ def run_pg_dump(export_filename, out_path, data_only, schema_name):
     data_only : bool
     schema_name : str
     """
-    export_path = os.path.join(out_path, export_filename)
+    if not os.path.isabs(export_filename):
+        export_path = os.path.join(out_path, export_filename)
+    else:
+        export_path = export_filename
     logger = logging.getLogger('pgosm-flex')
     db_name = 'pgosm'
     conn_string = connection_string(db_name=db_name)

--- a/docker/osm2pgsql_recommendation.py
+++ b/docker/osm2pgsql_recommendation.py
@@ -85,7 +85,7 @@ def get_recommended_script(system_ram_gb, osm_pbf_gb,
     osm2pgsql_cmd = re.sub(r'~/pgosm-data[^ ]+', pbf_filename, osm2pgsql_cmd)
     # Replace generic connection string with specific conn string
     if conn_str is None:
-        conn_string = db.connection_string(db_name='pgosm')
+        conn_str = db.connection_string(db_name='pgosm')
     osm2pgsql_cmd = osm2pgsql_cmd.replace('-d $PGOSM_CONN',
-                                          f'-d {conn_string}')
+                                          f'-d {conn_str}')
     return osm2pgsql_cmd

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -159,7 +159,7 @@ def run_pgosm_flex(layerset, layerset_path, ram, region, subregion, srid,
                                             layerset,
                                             pgosm_date)
     else:
-        export_filename = os.path.basename(input_file)[:-4] + '.sql'
+        export_filename = os.path.splitext(input_file)[0] + '.sql'
 
     if schema_name != 'osm':
         db.rename_schema(schema_name)

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -621,8 +621,7 @@ def remove_latest_files(region, subregion, paths):
     os.remove(md5_file)
 
 
-def get_osm2pgsql_command(
-    region, subregion, ram, paths, conn_str=None):
+def get_osm2pgsql_command(region, subregion, ram, paths, conn_str=None):
     """Returns recommended osm2pgsql command.
 
     Parameters


### PR DESCRIPTION
My typical use case for this tool is to ingest a PBF file I already have and load it into an arbitrary database that I have already running. This is something that is done internally by the tool but only to read a specific region/subregion file and load it in the "incorporated" PostGIS intance. To do that currently I use a bash script that is "injected" into the container, which is quite verbose and hard to troubleshoot.

This PR tries to make it a functionality of the tool without further trickery.

A few changes:
* the makefile now has an extra task which tests exactly this use case, I split build and run in different tasks to build only once
* all the functions operating on the DB have an optional connection string argument
* installing the postgis extension now tolerates the case in which it's already installed
* two new parameters are added to specify the input PBF file (in that case all the download logic is skipped) and a connection string. They can be used independently.

I tried to keep the changes minimal, probably the code can be refactored a bit, splitting the steps in different files and decoupled the download logic from the import. Also I'm wondering if it's really necessary to call a service to build the command line parameter, I think in most cases can just be passed from the command line.

Let me know what you think!