### PR TITLE
Logs go to stdout instead of internally defined logfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ mkdir ~/pgosm-data
 ```
 
 Set environment variables for the temporary Postgres connection in Docker.
+These are required for the Docker container to run.
+
 
 ```bash
 export POSTGRES_USER=postgres
@@ -74,11 +76,10 @@ docker run --name pgosm -d --rm \
 ```
 
 Run the processing for the Washington D.C.  The `docker/pgosm_flex.py` script
-requires three (3) parameters, typical use will use four (4) to include
+requires two (2) parameters, typical use will use three (3) to include
 the `--subregion`.
 
 
-* PgOSM-Flex layer set (`run-all`)
 * Total RAM for osm2pgsql, Postgres and OS (`8`)
 * Region (`north-america/us`)
 * Sub-region (`district-of-columbia`) (Optional)
@@ -87,10 +88,7 @@ the `--subregion`.
 
 ```bash
 docker exec -it \
-    -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD \
-    -e POSTGRES_USER=$POSTGRES_USER \
     pgosm python3 docker/pgosm_flex.py \
-    --layerset=run-all \
     --ram=8 \
     --region=north-america/us \
     --subregion=district-of-columbia

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -101,9 +101,8 @@ def run_pgosm_flex(layerset, layerset_path, ram, region, subregion,
         subregion = None
 
     paths = get_paths(base_path=basepath)
-    log_file = get_log_path(region, subregion, paths)
 
-    setup_logger(log_file, debug)
+    setup_logger(debug)
     logger = logging.getLogger('pgosm-flex')
     logger.info('PgOSM Flex starting...')
     prepare_data(region=region,
@@ -196,14 +195,11 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
 
 
 
-def setup_logger(log_file, debug):
+def setup_logger(debug):
     """Prepares logging.
 
     Parameters
     ------------------------------
-    log_file : str
-        Path to log file
-
     debug : bool
         Enables debug mode when True.  INFO when False.
     """
@@ -213,7 +209,7 @@ def setup_logger(log_file, debug):
         log_level = logging.INFO
 
     log_format = '%(asctime)s:%(levelname)s:%(name)s:%(module)s:%(message)s'
-    logging.basicConfig(filename=log_file,
+    logging.basicConfig(stream=sys.stdout,
                         level=log_level,
                         filemode='w',
                         format=log_format)
@@ -222,42 +218,8 @@ def setup_logger(log_file, debug):
     logging.getLogger('urllib3').setLevel(logging.INFO)
 
     logger = logging.getLogger('pgosm-flex')
-    logger.setLevel(log_level)
-    handler = logging.FileHandler(filename=log_file)
-    handler.setLevel(log_level)
-    formatter = logging.Formatter(log_format)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
     logger.debug('Logger configured')
 
-
-def get_log_path(region, subregion, paths):
-    """Returns path to log_file for given region/subregion.
-
-    Parameters
-    ---------------------
-    region : str
-    subregion : str
-    paths : dict
-
-    Returns
-    ---------------------
-    log_file : str
-    """
-    region_clean = region.replace('/', '-')
-    if subregion is None:
-        filename = f'{region_clean}.log'
-    else:
-        filename = f'{region_clean}-{subregion}.log'
-
-    # Users will see this when they run, can copy/paste tail command.
-    # Path matches path if following project's main README.md
-    print(f'Log filename: {filename}')
-    print('If running in Docker following procedures the file can be monitored')
-    print(f'  tail -f ~/pgosm-data/{filename}')
-
-    log_file = os.path.join(paths['out_path'], filename)
-    return log_file
 
 
 def get_paths(base_path):
@@ -622,7 +584,7 @@ def run_osm2pgsql(osm2pgsql_command, paths):
     paths : dict
     """
     logger = logging.getLogger('pgosm-flex')
-    logger.info(f'Running {osm2pgsql_command}')
+    logger.info(f'Running osm2pgsql')
 
     output = subprocess.run(osm2pgsql_command.split(),
                             text=True,

--- a/docs/DOCKER-RUN.md
+++ b/docs/DOCKER-RUN.md
@@ -58,12 +58,12 @@ The 3rd parameter tells the script the server has 8 GB RAM available for osm2pgs
 
 ```bash
 docker exec -it \
-    -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -e POSTGRES_USER=$POSTGRES_USER \
     pgosm python3 docker/pgosm_flex.py \
     --layerset=default \
     --ram=8 \
     --region=north-america/us \
-    --subregion=district-of-columbia
+    --subregion=district-of-columbia \
+    &> ~/pgosm-data/pgosm-flex.log
 ```
 
 
@@ -121,7 +121,6 @@ used during development.
 
 ```bash
 docker exec -it \
-    -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD  -e POSTGRES_USER=$POSTGRES_USER \
     pgosm python3 docker/pgosm_flex.py \
     --layerset=poi \
     --layerset-path=/custom-layerset/ \
@@ -164,7 +163,6 @@ Define the layerset name (`--layerset=poi`) and path
 
 ```bash
 docker exec -it \
-    -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD -e POSTGRES_USER=$POSTGRES_USER \
     pgosm python3 docker/pgosm_flex.py \
     --layerset=poi \
     --layerset-path=/custom-layerset/ \


### PR DESCRIPTION
Based on suggestions from @jacopofar in #186 ([comment](https://github.com/rustprooflabs/pgosm-flex/pull/186/files/93446a1a9731052fd9bd532ee6e3f93fba5a9125#r738348780)) to not force logs into a logfile, instead letting the user control what happens.

* Redirects log output from file to stdout
* No longer logs `osm2pgsql_command` to avoid showing password
* Update `docker exec` examples to remove unnecessary env vars passed in

