### PR TITLE
Enable explicit input file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,7 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		--layerset=default \
 		--ram=1 \
 		--region=north-america/us \
-		--subregion=district-of-columbia \
-		--debug
+		--subregion=district-of-columbia
 
 	# process it, this time without providing the region but directly the filename
 	docker exec -it \
@@ -68,8 +67,8 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		pgosm python3 docker/pgosm_flex.py  \
 		--layerset=default \
 		--ram=1 \
-		--input-file=/app/output/$(INPUT_FILE_NAME) \
-		--debug
+		--input-file=/app/output/$(INPUT_FILE_NAME)
+
 
 .PHONY: unit-tests
 unit-tests: ## Runs Python unit tests and data import tests

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		pgosm:/app/output/district-of-columbia-$(TODAY).osm.pbf
 	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf.md5 \
 		pgosm:/app/output/district-of-columbia-$(TODAY).osm.pbf.md5
+	# copy the test data with a meaningless name
+	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf \
+		pgosm:/app/output/some_arbitrary_name.osm.pbf
 
 	# allow files created in later step to be created
 	docker exec -it pgosm \
@@ -54,7 +57,16 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		--region=north-america/us \
 		--subregion=district-of-columbia \
 		--debug
-
+	# process it, this time without providing the region but directly the filename
+	docker exec -it \
+		-e POSTGRES_PASSWORD=mysecretpassword \
+		-e POSTGRES_USER=postgres \
+		-u $(CURRENT_UID):$(CURRENT_GID) \
+		pgosm python3 docker/pgosm_flex.py  \
+		--layerset=run-all \
+		--ram=1 \
+		--input-file=/app/output/some_arbitrary_name.osm.pbf \
+		--debug
 
 .PHONY: unit-tests
 unit-tests: ## Runs Python unit tests and data import tests

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 TODAY := $(shell date +'%Y-%m-%d')
+INPUT_FILE_NAME='custom_source_file.osm.pbf'
 
 .PHONY: all
 all: docker-clean build-run-docker unit-tests
@@ -36,9 +37,9 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		pgosm:/app/output/district-of-columbia-$(TODAY).osm.pbf
 	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf.md5 \
 		pgosm:/app/output/district-of-columbia-$(TODAY).osm.pbf.md5
-	# copy the test data with a meaningless name
+	# copy with arbitrary file name to test --input-file
 	docker cp tests/data/district-of-columbia-2021-01-13.osm.pbf \
-		pgosm:/app/output/some_arbitrary_name.osm.pbf
+		pgosm:/app/output/$(INPUT_FILE_NAME)
 
 	# allow files created in later step to be created
 	docker exec -it pgosm \
@@ -47,6 +48,7 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 	docker exec -it pgosm \
 		chown $(CURRENT_UID):$(CURRENT_GID) /app/docker/
 
+	# run typical processing using built-in file handling
 	docker exec -it \
 		-e POSTGRES_PASSWORD=mysecretpassword \
 		-e POSTGRES_USER=postgres \
@@ -57,15 +59,16 @@ build-run-docker: ## Builds and runs PgOSM Flex with D.C. test file
 		--region=north-america/us \
 		--subregion=district-of-columbia \
 		--debug
+
 	# process it, this time without providing the region but directly the filename
 	docker exec -it \
 		-e POSTGRES_PASSWORD=mysecretpassword \
 		-e POSTGRES_USER=postgres \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		pgosm python3 docker/pgosm_flex.py  \
-		--layerset=run-all \
+		--layerset=default \
 		--ram=1 \
-		--input-file=/app/output/some_arbitrary_name.osm.pbf \
+		--input-file=/app/output/$(INPUT_FILE_NAME) \
 		--debug
 
 .PHONY: unit-tests

--- a/docker/db.py
+++ b/docker/db.py
@@ -377,7 +377,10 @@ def run_pg_dump(export_filename, out_path, data_only, schema_name):
     data_only : bool
     schema_name : str
     """
-    export_path = os.path.join(out_path, export_filename)
+    if not os.path.isabs(export_filename):
+        export_path = os.path.join(out_path, export_filename)
+    else:
+        export_path = export_filename
     logger = logging.getLogger('pgosm-flex')
     db_name = 'pgosm'
     conn_string = connection_string(db_name=db_name)

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -91,7 +91,7 @@ def get_today():
 @click.option('--input-file',
               required=False,
               default=None,
-              help='Path of the input PBF file')
+              help='Set explicit filepath to input osm.pbf file. Overrides default file handling, archiving, and MD5 checksum.')
 def run_pgosm_flex(layerset, layerset_path, ram, region, subregion, srid,
                     pgosm_date, language, schema_name, skip_nested, data_only,
                     skip_dump, debug, basepath, input_file):
@@ -105,13 +105,15 @@ def run_pgosm_flex(layerset, layerset_path, ram, region, subregion, srid,
     logger = logging.getLogger('pgosm-flex')
     logger.info('PgOSM Flex starting...')
 
+    set_env_vars(region, subregion, srid, language, pgosm_date,
+                 layerset, layerset_path)
+
     if input_file is None:
         prepare_data(region=region,
                     subregion=subregion,
                     pgosm_date=pgosm_date,
                     paths=paths)
-        set_env_vars(region, subregion, srid, language, pgosm_date,
-                    layerset, layerset_path)
+
         osm2pgsql_command = get_osm2pgsql_command(region=region,
                                                 subregion=subregion,
                                                 ram=ram,
@@ -609,8 +611,6 @@ def run_osm2pgsql(osm2pgsql_command, paths):
 
     logger.info('osm2pgsql completed.')
 
-    # output from PgOSM Flex lua goes to stdout
-    logger.info(f'PgOSM Flex output: \n {output}\nEND PgOSM Flex output')
 
 def check_layerset_places(layerset_path, layerset, paths):
     """If `place` layer is not included `skip_nested` should be true.


### PR DESCRIPTION
# Details

Closes #192.

Pulled `--input-file` feature from @jacopofar commit 2662624 from #186.  Updated for changes made in 0.4.0.

Other changes in this PR:

* Adjusted the output filename to match the existing filename pattern
* Improved handling of input filename passed to osm2pgsql recommendation
* Removed `--debug` from make commands
