### PR TITLE
Fix subregion bug, improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 ## ----------------------------------------------------------------------
 ## This Makefile builds and tests the PgOSM Flex Docker image.
 ##
-## For full build/test use:
+## For full build/test use (runs multiple import formats):
 ##    make
+##
+## To run region/subregion test + unit tests:
+##    make docker-exec-default unit-tests
 ##
 ## To cleanup after you are done:
 ##    make docker-clean

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -54,7 +54,6 @@ def get_today():
               default="north-america/us",
               help='Region name matching the filename for data sourced from Geofabrik. e.g. north-america/us. Optional when --input-file is specified, otherwise required.')
 @click.option('--subregion', required=False,
-              default="district-of-columbia",
               show_default="district-of-columbia",
               help='Sub-region name matching the filename for data sourced from Geofabrik. e.g. district-of-columbia')
 @click.option('--srid', required=False, default=DEFAULT_SRID,

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -295,7 +295,8 @@ def get_export_filename(region, subregion, layerset, pgosm_date, input_file):
     filename : str
     """
     region = region.replace('/', '-')
-    subregion = subregion.replace('/', '-')
+    if subregion:
+        subregion = subregion.replace('/', '-')
 
     if input_file:
         # Assumes .osm.pbf

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -294,6 +294,7 @@ def get_export_filename(region, subregion, layerset, pgosm_date, input_file):
     ----------------------
     filename : str
     """
+    # region is always set internally, even with --input-file and no --region
     region = region.replace('/', '-')
     if subregion:
         subregion = subregion.replace('/', '-')


### PR DESCRIPTION
# Details

* Will resolve #197
* Addresses the Makefile portion of #199.

The fix for #197 is straightforward, sorry for the oversight!  The updates to the Makefile adds a new test for the region specific logic.


## Makefile notes

Previously had daisy-chained the build, copy, permissions, and `docker exec` commands into one big target.  This splits that logic out so each `docker-exec` is within its own target which starts by cleaning the environment, builds/runs the container, copies the file(s) needed, and runs docker-exec.

There are 3 `docker-exec-*` targets that ensure the main variations for processing work.

