### PR TITLE
Improve usability around region/subregion

### DIFF
--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -175,11 +175,11 @@ def validate_region_inputs(region, subregion, input_file):
         raise ValueError('Either --region or --input-file must be provided')
 
     if region is None and subregion is not None:
-        raise ValueError('Using --subregion requires value for --region')
+        raise ValueError('Cannot use --subregion without --region')
 
     if region is not None:
         if '/' in region and subregion is None:
-            raise ValueError('Region provided appears to include subregion. The portion after the FINAL "/" in the Geofabrik URL should be the --subregion.')
+            raise ValueError('Region provided appears to include subregion. The portion after the final "/" in the Geofabrik URL should be the --subregion.')
 
 
 def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -97,8 +97,12 @@ def run_pgosm_flex(layerset, layerset_path, ram, region, subregion, srid,
     """Logic to run PgOSM Flex within Docker.
     """
     if region is None and input_file is None:
-        raise ValueError("either region or input_file must be provided")
+        raise ValueError('Either --region or --input-file must be provided')
 
+    if '/' in region and subregion is None:
+        raise ValueError('Region provided appears to include subregion. The portion after the FINAL "/" in the Geofabrik URL should be the --subregion.')
+
+    # Ensure always a region name
     if region is None and input_file:
         region = input_file
 

--- a/docs/DOCKER-RUN.md
+++ b/docs/DOCKER-RUN.md
@@ -54,8 +54,13 @@ script uses a region (`--region=north-america/us`) and
 sub-region (`--subregion=district-of-columbia`).
 The region/subregion values must the URL pattern used by the Geofabrik download server,
 see the [Regions and Subregions](#regions-and-subregions) section.
+
 The `--ram=8` parameter defines the total system RAM available and is used by
 internal logic to determine the best osm2pgsql options to use.
+When running on hardware dedicated to this process it is safe to define the total
+system RAM.  If the process is on a computer with other responsibilities, such
+as your laptop, feel free to lower this value.
+
 
 ```bash
 docker exec -it \
@@ -64,6 +69,12 @@ docker exec -it \
     --region=north-america/us \
     --subregion=district-of-columbia
 ```
+
+For the best in-Docker performance you will need to
+[tune the internal Postgres config](configure-postgres-in-docker) appropriately
+for your hardware.
+See the [osm2pgsql documentation](https://osm2pgsql.org/doc/manual.html#tuning-the-postgresql-server) for more on tuning Postgres for this
+process.
 
 
 ## Regions and Subregions

--- a/docs/DOCKER-RUN.md
+++ b/docs/DOCKER-RUN.md
@@ -67,6 +67,29 @@ docker exec -it \
 ```
 
 
+## Regions and Subregions
+
+The `--region` and `--subregion` definitions must match
+the Geofabrik URL scheme.  This can be a bit confusing
+as larger subregions can contain additional, smaller subregions
+which are reflected in these values.
+
+The example above for the `district-of-columbia` subregion defines
+`--region=north-america/us`.  You cannot, unfortunately, drop off
+the `--subregion` to load the U.S. subregion. Attempting this results
+in a `ValueError`.
+
+To load the U.S. subregion, the `us` portion drops out of `--region`
+and moves to `--subregion`.
+
+```bash
+docker exec -it pgosm python3 docker/pgosm_flex.py \
+    --ram=8 \
+    --region=north-america \
+    --subregion=us
+```
+
+
 ## Customize PgOSM-Flex
 
 See full set of options via `--help`.

--- a/docs/DOCKER-RUN.md
+++ b/docs/DOCKER-RUN.md
@@ -71,7 +71,7 @@ docker exec -it \
 ```
 
 For the best in-Docker performance you will need to
-[tune the internal Postgres config](configure-postgres-in-docker) appropriately
+[tune the internal Postgres config](#configure-postgres-in-docker) appropriately
 for your hardware.
 See the [osm2pgsql documentation](https://osm2pgsql.org/doc/manual.html#tuning-the-postgresql-server) for more on tuning Postgres for this
 process.

--- a/docs/DOCKER-RUN.md
+++ b/docs/DOCKER-RUN.md
@@ -48,22 +48,21 @@ docker ps -a | grep pgosm
 ## Run PgOSM-Flex
 
 The following `docker exec` command runs PgOSM Flex to load the District of Columbia
-region
-
+region.
 The command  `python3 docker/pgosm_flex.py` runs the full process. The
-script uses a region (`north-america/us`) and sub-region (`district-of-columbia`)
-that must match values in URLs from the Geofabrik download server.
-The 3rd parameter tells the script the server has 8 GB RAM available for osm2pgsql, Postgres, and the OS.  The PgOSM-Flex layer set is defined (`default`).
-
+script uses a region (`--region=north-america/us`) and
+sub-region (`--subregion=district-of-columbia`).
+The region/subregion values must the URL pattern used by the Geofabrik download server,
+see the [Regions and Subregions](#regions-and-subregions) section.
+The `--ram=8` parameter defines the total system RAM available and is used by
+internal logic to determine the best osm2pgsql options to use.
 
 ```bash
 docker exec -it \
     pgosm python3 docker/pgosm_flex.py \
-    --layerset=default \
     --ram=8 \
     --region=north-america/us \
-    --subregion=district-of-columbia \
-    &> ~/pgosm-data/pgosm-flex.log
+    --subregion=district-of-columbia
 ```
 
 
@@ -71,10 +70,9 @@ docker exec -it \
 
 The `--region` and `--subregion` definitions must match
 the Geofabrik URL scheme.  This can be a bit confusing
-as larger subregions can contain additional, smaller subregions
-which are reflected in these values.
+as larger subregions can contain smaller subregions.
 
-The example above for the `district-of-columbia` subregion defines
+The example above to process the `district-of-columbia` subregion defines
 `--region=north-america/us`.  You cannot, unfortunately, drop off
 the `--subregion` to load the U.S. subregion. Attempting this results
 in a `ValueError`.


### PR DESCRIPTION
Issue reported in #198 can't be resolved by improving the file name handling, at least not easily. The issue stems from the decision to tightly couple to Geofabrik's download server.  This PR raises an error when a slash is detected in the region name and subregion is none, in these cases the portion after the last `/` should be in the subregion.

This also updates the documentation to add a section about the region/subregion, and show this example.  I'm sure there's room for improvement in the wording, this is a quick start to improve this.