### PR TITLE
Cleanup Postgres connections, paths, and testing

### DIFF
--- a/docker/db.py
+++ b/docker/db.py
@@ -165,7 +165,7 @@ def pg_version_check():
     """
     sql_raw = 'SHOW server_version;'
 
-    with get_db_conn(db_name='postgres') as conn:
+    with get_db_conn(conn_string=os.environ['PGOSM_CONN_PG']) as conn:
         cur = conn.cursor()
         cur.execute(sql_raw)
         results = cur.fetchone()
@@ -179,7 +179,7 @@ def pg_version_check():
 def drop_pgosm_db():
     """Drops the pgosm database if it exists."""
     sql_raw = 'DROP DATABASE IF EXISTS pgosm;'
-    conn = get_db_conn(db_name='postgres')
+    conn = get_db_conn(conn_string=os.environ['PGOSM_CONN_PG'])
 
     LOGGER.debug('Setting Pg conn to enable autocommit - required for drop/create DB')
     conn.autocommit = True
@@ -192,7 +192,7 @@ def create_pgosm_db():
     """Creates the pgosm database and prepares with PostGIS and osm schema
     """
     sql_raw = 'CREATE DATABASE pgosm;'
-    conn = get_db_conn(db_name='postgres')
+    conn = get_db_conn(conn_string=os.environ['PGOSM_CONN_PG'])
 
     LOGGER.debug('Setting Pg conn to enable autocommit - required for drop/create DB')
     conn.autocommit = True
@@ -203,7 +203,7 @@ def create_pgosm_db():
     sql_create_postgis = "CREATE EXTENSION postgis;"
     sql_create_schema = "CREATE SCHEMA osm;"
 
-    with get_db_conn(db_name='pgosm') as conn:
+    with get_db_conn(conn_string=os.environ['PGOSM_CONN']) as conn:
         cur = conn.cursor()
         cur.execute(sql_create_postgis)
         LOGGER.debug('Installed PostGIS extension')
@@ -278,7 +278,7 @@ def load_qgis_styles(db_path):
     with open(load_path, 'r') as file_in:
         load_sql = file_in.read()
 
-    with get_db_conn(db_name='pgosm') as conn:
+    with get_db_conn(conn_string=os.environ['PGOSM_CONN']) as conn:
         cur = conn.cursor()
         cur.execute(create_sql)
     LOGGER.debug('QGIS Style table created')
@@ -297,12 +297,12 @@ def load_qgis_styles(db_path):
 
     LOGGER.debug(f'Output from loading QGIS style data: {output.stdout}')
 
-    with get_db_conn(db_name='pgosm') as conn:
+    with get_db_conn(conn_string=os.environ['PGOSM_CONN']) as conn:
         cur = conn.cursor()
         cur.execute(load_sql)
     LOGGER.info('QGIS Style table populated')
 
-    with get_db_conn(db_name='pgosm') as conn:
+    with get_db_conn(conn_string=os.environ['PGOSM_CONN']) as conn:
         sql_clean = 'DELETE FROM public.layer_styles_staging;'
         cur = conn.cursor()
         cur.execute(sql_clean)
@@ -335,18 +335,17 @@ def sqitch_db_string(db_name):
 
 
 
-def get_db_conn(db_name):
+def get_db_conn(conn_string):
     """Establishes psycopg database connection.
 
     Parameters
     -----------------------
-    db_name : str
+    conn_string : str
 
     Returns
     -----------------------
     conn : psycopg.Connection
     """
-    conn_string = connection_string(db_name)
     try:
         conn = psycopg.connect(conn_string)
         LOGGER.debug('Connection to Postgres established')
@@ -418,7 +417,7 @@ def rename_schema(schema_name):
     LOGGER.info(f'Renaming schema from osm to {schema_name}')
     sql_raw = f'ALTER SCHEMA osm RENAME TO {schema_name} ;'
 
-    with get_db_conn(db_name='pgosm') as conn:
+    with get_db_conn(conn_string=os.environ['PGOSM_CONN']) as conn:
         cur = conn.cursor()
         cur.execute(sql_raw)
 

--- a/docker/db.py
+++ b/docker/db.py
@@ -224,7 +224,7 @@ def run_sqitch_prep(db_path):
     """
     LOGGER.info('Deploy schema via Sqitch')
 
-    conn_string = connection_string(db_name='pgosm')
+    conn_string = os.environ['PGOSM_CONN']
     conn_string_sqitch = sqitch_db_string(db_name='pgosm')
 
     cmds_sqitch = ['sqitch', 'deploy', conn_string_sqitch]
@@ -285,7 +285,7 @@ def load_qgis_styles(db_path):
 
     # Loading layer_styles data is done from files created by pg_dump, using
     # psql to reload is easiest
-    conn_string = connection_string(db_name='pgosm')
+    conn_string = os.environ['PGOSM_CONN']
     cmds_populate = ['psql', '-d', conn_string,
                      '-f', 'qgis-style/layer_styles.sql']
 
@@ -358,7 +358,7 @@ def get_db_conn(db_name):
     return conn
 
 
-def pgosm_after_import(paths):
+def pgosm_after_import(flex_path):
     """Runs post-processing SQL via Lua script.
 
     Layerset logic is established via environment variable, must happen
@@ -366,7 +366,7 @@ def pgosm_after_import(paths):
 
     Parameters
     ---------------------
-    paths : dict
+    flex_path : str
     """
     LOGGER.info('Running post-processing...')
 
@@ -375,7 +375,7 @@ def pgosm_after_import(paths):
     output = subprocess.run(cmds,
                             text=True,
                             capture_output=True,
-                            cwd=paths['flex_path'],
+                            cwd=flex_path,
                             check=True)
     LOGGER.info(f'Post-processing output: \n {output.stderr}')
 
@@ -389,7 +389,7 @@ def pgosm_nested_admin_polygons(paths):
     """
     sql_raw = 'CALL osm.build_nested_admin_polygons();'
 
-    conn_string = connection_string(db_name='pgosm')
+    conn_string = os.environ['PGOSM_CONN']
     cmds = ['psql', '-d', conn_string, '-c', sql_raw]
     LOGGER.info('Building nested polygons... (this can take a while)')
     output = subprocess.run(cmds,
@@ -439,7 +439,7 @@ def run_pg_dump(export_filename, out_path, data_only, schema_name):
         export_path = export_filename
     logger = logging.getLogger('pgosm-flex')
     db_name = 'pgosm'
-    conn_string = connection_string(db_name=db_name)
+    conn_string = os.environ['PGOSM_CONN']
 
     if data_only:
         logger.info(f'Running pg_dump (only {schema_name} schema)')

--- a/docker/geofabrik.py
+++ b/docker/geofabrik.py
@@ -29,7 +29,7 @@ def get_region_filename(region, subregion):
     return filename
 
 
-def prepare_data(region, subregion, pgosm_date, paths):
+def prepare_data(region, subregion, pgosm_date, out_path):
     """Ensures the PBF file is available.
 
     Checks if it already exists locally, download if needed,
@@ -40,14 +40,13 @@ def prepare_data(region, subregion, pgosm_date, paths):
     region : str
     subregion : str
     pgosm_date : str
-    paths : dict
+    out_path : str
 
     Returns
     ----------------------
     pbf_file : str
         Full path to PBF file
     """
-    out_path = paths['out_path']
     pbf_filename = get_region_filename(region, subregion)
 
     pbf_file = os.path.join(out_path, pbf_filename)

--- a/docker/geofabrik.py
+++ b/docker/geofabrik.py
@@ -64,7 +64,7 @@ def prepare_data(region, subregion, pgosm_date, paths):
         logging.getLogger('pgosm-flex').info('Copying Archived files')
         unarchive_data(pbf_file, md5_file, pbf_file_with_date, md5_file_with_date)
 
-    helpers.verify_checksum(md5_file, paths['out_path'])
+    helpers.verify_checksum(md5_file, out_path)
 
     return pbf_file
 

--- a/docker/osm2pgsql_recommendation.py
+++ b/docker/osm2pgsql_recommendation.py
@@ -49,7 +49,7 @@ def osm2pgsql_recommendation(ram, pbf_filename, out_path):
 
 def get_recommended_script(system_ram_gb, osm_pbf_gb, append, pbf_filename,
                            output_path):
-    """Builds API call and cleans up returned command for use here.
+    """Generates recommended osm2pgsql command from osm2pgsql-tuner.
 
     Parameters
     -------------------------------

--- a/docker/osm2pgsql_recommendation.py
+++ b/docker/osm2pgsql_recommendation.py
@@ -30,7 +30,7 @@ def osm2pgsql_recommendation(ram, pbf_filename, out_path):
     """
     system_ram_gb = ram
     # The layerset is now set via env var.  This is used to set filename for osm2pgsql command
-    pgosm_layer_set = 'run'
+
     if not os.path.isabs(pbf_filename):
         pbf_file = os.path.join(out_path, pbf_filename)
     else:
@@ -44,13 +44,10 @@ def osm2pgsql_recommendation(ram, pbf_filename, out_path):
                                            osm_pbf_gb,
                                            append,
                                            pbf_file,
-                                           pgosm_layer_set,
                                            out_path)
     return osm2pgsql_cmd
 
-def get_recommended_script(system_ram_gb, osm_pbf_gb,
-                           append, pbf_filename,
-                           pgosm_layer_set,
+def get_recommended_script(system_ram_gb, osm_pbf_gb, append, pbf_filename,
                            output_path):
     """Builds API call and cleans up returned command for use here.
 
@@ -61,7 +58,6 @@ def get_recommended_script(system_ram_gb, osm_pbf_gb,
     append : bool
     pbf_filename : str
         Can be filename or absolute path.
-    pgosm_layer_set : str
     output_path : str
 
     Returns
@@ -79,8 +75,7 @@ def get_recommended_script(system_ram_gb, osm_pbf_gb,
     rec = tuner.recommendation(system_ram_gb=system_ram_gb,
                                osm_pbf_gb=osm_pbf_gb,
                                append=append,
-                               ssd=True,
-                               pgosm_layer_set=pgosm_layer_set)
+                               ssd=True)
 
     # FIXME: Currently requires .osm.pbf input. Will block full functionality of #192
     # Uses basename to work with absolute paths

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -213,6 +213,8 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
     # PGOSM_CONN is required by Lua scripts for osm2pgsql. This should
     # be the only place a connection string is defined outside of Sqitch usage.
     os.environ['PGOSM_CONN'] = db.connection_string(db_name='pgosm')
+    # Connection to DB for admin purposes, e.g. drop/create main database
+    os.environ['PGOSM_CONN_PG'] = db.connection_string(db_name='postgres')
 
 
 def unset_env_vars():
@@ -225,6 +227,7 @@ def unset_env_vars():
     os.environ.pop('PGOSM_DATE', None)
     os.environ.pop('PGOSM_LAYERSET', None)
     os.environ.pop('PGOSM_CONN', None)
+    os.environ.pop('PGOSM_CONN_PG', None)
 
 
 def setup_logger(debug):

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -97,7 +97,7 @@ def run_pgosm_flex(layerset, layerset_path, ram, region, subregion, srid,
         geofabrik.prepare_data(region=region,
                                subregion=subregion,
                                pgosm_date=pgosm_date,
-                               paths=paths)
+                               out_path=paths['out_path'])
 
         pbf_filename = geofabrik.get_region_filename(region, subregion)
         osm2pgsql_command = rec.osm2pgsql_recommendation(ram=ram,
@@ -110,7 +110,7 @@ def run_pgosm_flex(layerset, layerset_path, ram, region, subregion, srid,
 
     db.wait_for_postgres()
 
-    db.prepare_pgosm_db(data_only=data_only, paths=paths)
+    db.prepare_pgosm_db(data_only=data_only, db_path=paths['db_path'])
 
     run_osm2pgsql(osm2pgsql_command=osm2pgsql_command, paths=paths)
 

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -209,9 +209,9 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
         os.environ['PGOSM_LAYERSET_PATH'] = str(layerset_path)
 
     os.environ['PGOSM_DATE'] = pgosm_date
-
     os.environ['PGOSM_LAYERSET'] = layerset
-
+    # PGOSM_CONN is required by Lua scripts for osm2pgsql. This should
+    # be the only place a connection string is defined outside of Sqitch usage.
     os.environ['PGOSM_CONN'] = db.connection_string(db_name='pgosm')
 
 
@@ -365,11 +365,9 @@ def check_layerset_places(layerset_path, layerset, paths):
     try:
         place = config['layerset']['place']
     except KeyError:
-        # No place key, skip_nested should be true
         logger.debug('Place layer not defined, setting skip_nested')
         return True
 
-    # If Place is true
     if place:
         logger.debug('Place layer is defined as true. Not setting skip_nested')
         return False
@@ -389,14 +387,13 @@ def run_post_processing(paths, skip_nested):
 
     skip_nested : bool
     """
-    db.pgosm_after_import(paths)
+    db.pgosm_after_import(paths['flex_path'])
     logger = logging.getLogger('pgosm-flex')
     if skip_nested:
         logger.info('Skipping calculating nested polygons')
     else:
         logger.info('Calculating nested polygons')
         db.pgosm_nested_admin_polygons(paths)
-
 
 
 if __name__ == "__main__":

--- a/docker/tests/test_db.py
+++ b/docker/tests/test_db.py
@@ -13,6 +13,7 @@ PG_USER_ONLY = {'POSTGRES_USER': POSTGRES_USER,
 PG_USER_AND_PW = {'POSTGRES_USER': POSTGRES_USER,
                   'POSTGRES_PASSWORD': POSTGRES_PASSWORD}
 
+
 class DBTests(unittest.TestCase):
 
     @mock.patch.dict(os.environ, PG_USER_ONLY)
@@ -38,6 +39,7 @@ class DBTests(unittest.TestCase):
         expected = f'postgresql://{POSTGRES_USER}@localhost/pgosm?application_name=pgosm-flex'
         result = db.connection_string(db_name='pgosm')
         self.assertEqual(expected, result)
+
 
     @mock.patch.dict(os.environ, PG_USER_AND_PW)
     def test_connection_string_user_w_pw_returns_expected_string(self):

--- a/docker/tests/test_geofabrik.py
+++ b/docker/tests/test_geofabrik.py
@@ -5,6 +5,7 @@ import geofabrik
 REGION_US = 'north-america/us'
 SUBREGION_DC = 'district-of-columbia'
 
+
 class GeofabrikTests(unittest.TestCase):
 
     def test_get_region_filename_returns_subregion_when_exists(self):

--- a/docker/tests/test_helpers.py
+++ b/docker/tests/test_helpers.py
@@ -2,7 +2,6 @@
 import os
 import unittest
 
-
 import pgosm_flex, helpers
 
 pgosm_flex.setup_logger(debug=True)
@@ -14,7 +13,6 @@ class HelpersTests(unittest.TestCase):
         expected = str
         actual = type(helpers.get_today())
         self.assertEqual(expected, actual)
-
 
     def test_verify_checksum_returns_None_when_valid_md5(self):
         txt_file = 'checksum-test.txt'

--- a/docker/tests/test_helpers.py
+++ b/docker/tests/test_helpers.py
@@ -1,0 +1,53 @@
+""" Unit tests to cover the DB module."""
+import os
+import unittest
+
+
+import pgosm_flex, helpers
+
+pgosm_flex.setup_logger(debug=True)
+
+
+class HelpersTests(unittest.TestCase):
+
+    def test_get_today_returns_str(self):
+        expected = str
+        actual = type(helpers.get_today())
+        self.assertEqual(expected, actual)
+
+
+    def test_verify_checksum_returns_None_when_valid_md5(self):
+        txt_file = 'checksum-test.txt'
+        md5_file = f'{txt_file}.md5'
+
+        path = os.getcwd()
+        txt_content = 'this is a test'
+        md5_content = f'54b0c58c7ce9f2a8b551351102ee0938  {txt_file}'
+
+        with open(txt_file, "w") as f:
+            f.write(txt_content)
+
+        with open(md5_file, "w") as f:
+            f.write(md5_content)
+
+        expected = None
+        actual = helpers.verify_checksum(md5_file=md5_file, path=path)
+        self.assertEqual(expected, actual)
+
+    def test_verify_checksum_raises_SystemExit_invalid_md5(self):
+        txt_file = 'checksum-test.txt'
+        md5_file = f'{txt_file}.md5'
+
+        path = os.getcwd()
+        txt_content = 'data has been changed oh no'
+        md5_content = f'54b0c58c7ce9f2a8b551351102ee0938  {txt_file}'
+
+        with open(txt_file, "w") as f:
+            f.write(txt_content)
+
+        with open(md5_file, "w") as f:
+            f.write(md5_content)
+
+        with self.assertRaises(SystemExit):
+            helpers.verify_checksum(md5_file=md5_file, path=path)
+

--- a/docker/tests/test_osm2pgsql_recommendation.py
+++ b/docker/tests/test_osm2pgsql_recommendation.py
@@ -1,0 +1,41 @@
+""" Unit tests to cover the osm2pgsql_recommendation module."""
+import os
+import unittest
+
+import osm2pgsql_recommendation
+
+
+class Osm2pgsqlRecommendationTests(unittest.TestCase):
+
+    def test_get_recommended_script_returns_str(self):
+        expected = str
+        system_ram_gb = 1
+        osm_pbf_gb = 10
+        append = False
+        pbf_filename = 'This-is-a-test.osm.pbf'
+        pgosm_layer_set = 'default'
+        output_path = 'this-is-a-test'
+        result = osm2pgsql_recommendation.get_recommended_script(system_ram_gb,
+                                                                 osm_pbf_gb,
+                                                                 append,
+                                                                 pbf_filename,
+                                                                 pgosm_layer_set,
+                                                                 output_path)
+        actual = type(result)
+        self.assertEqual(expected, actual)
+
+    def test_get_recommended_script_returns_expected_str(self):
+        expected = 'osm2pgsql -d postgresql://postgres:mysecretpassword@localhost/pgosm?application_name=pgosm-flex  --cache=0  --slim  --drop  --flat-nodes=/tmp/nodes  --output=flex --style=./default.lua  this-is-a-test/This-is-a-test.osm.pbf'
+        system_ram_gb = 1
+        osm_pbf_gb = 10
+        append = False
+        pbf_filename = 'This-is-a-test.osm.pbf'
+        pgosm_layer_set = 'default'
+        output_path = 'this-is-a-test'
+        actual = osm2pgsql_recommendation.get_recommended_script(system_ram_gb,
+                                                                 osm_pbf_gb,
+                                                                 append,
+                                                                 pbf_filename,
+                                                                 pgosm_layer_set,
+                                                                 output_path)
+        self.assertEqual(expected, actual)

--- a/docker/tests/test_osm2pgsql_recommendation.py
+++ b/docker/tests/test_osm2pgsql_recommendation.py
@@ -13,29 +13,25 @@ class Osm2pgsqlRecommendationTests(unittest.TestCase):
         osm_pbf_gb = 10
         append = False
         pbf_filename = 'This-is-a-test.osm.pbf'
-        pgosm_layer_set = 'default'
         output_path = 'this-is-a-test'
         result = osm2pgsql_recommendation.get_recommended_script(system_ram_gb,
                                                                  osm_pbf_gb,
                                                                  append,
                                                                  pbf_filename,
-                                                                 pgosm_layer_set,
                                                                  output_path)
         actual = type(result)
         self.assertEqual(expected, actual)
 
     def test_get_recommended_script_returns_expected_str(self):
-        expected = 'osm2pgsql -d postgresql://postgres:mysecretpassword@localhost/pgosm?application_name=pgosm-flex  --cache=0  --slim  --drop  --flat-nodes=/tmp/nodes  --output=flex --style=./default.lua  this-is-a-test/This-is-a-test.osm.pbf'
+        expected = 'osm2pgsql -d postgresql://postgres:mysecretpassword@localhost/pgosm?application_name=pgosm-flex  --cache=0  --slim  --drop  --flat-nodes=/tmp/nodes  --output=flex --style=./run.lua  this-is-a-test/This-is-a-test.osm.pbf'
         system_ram_gb = 1
         osm_pbf_gb = 10
         append = False
         pbf_filename = 'This-is-a-test.osm.pbf'
-        pgosm_layer_set = 'default'
         output_path = 'this-is-a-test'
         actual = osm2pgsql_recommendation.get_recommended_script(system_ram_gb,
                                                                  osm_pbf_gb,
                                                                  append,
                                                                  pbf_filename,
-                                                                 pgosm_layer_set,
                                                                  output_path)
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Progresses #193

* Improve `helpers.verify_checksum()`, add unit tests
* Passing explicit path (`db_path`, `flex_path`) instead of full `paths` dict - Makes clearer what is used where
* Consolidate handling of Postgres connections through the `PGOSM_CONN` env var -- that var is required by the Lua scripts so made sense to standardize on that