### PR TITLE
Track osm2pgsql mode (create/append) in osm.pgosm_flex table

### DIFF
--- a/flex-config/sql/pgosm-meta.sql
+++ b/flex-config/sql/pgosm-meta.sql
@@ -10,3 +10,4 @@ COMMENT ON COLUMN osm.pgosm_flex.pgosm_flex_version IS 'Version of PgOSM-Flex us
 COMMENT ON COLUMN osm.pgosm_flex.osm2pgsql_version IS 'Version of osm2pgsql used to load data.';
 COMMENT ON COLUMN osm.pgosm_flex.region IS 'Region specified at run time via env var PGOSM_REGION.';
 COMMENT ON COLUMN osm.pgosm_flex.language IS 'Preferred language specified at run time via env var PGOSM_LANGUAGE.  Empty string when not defined.';
+COMMENT ON COLUMN osm.pgosm_flex.osm2pgsql_mode IS 'Indicates which osm2pgsql mode was used, create or append.';


### PR DESCRIPTION
Add `osm2pgsql_mode` column to track when create/append mode was used.  Will benefit #211.