### PR TITLE
Continue reducing use of paths dict in favor of specific values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,13 @@ unit-tests: ## Runs Python unit tests and data import tests
 		-e POSTGRES_PASSWORD=mysecretpassword \
 		-e POSTGRES_USER=postgres \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
-		pgosm /bin/bash -c "cd docker && coverage run -m unittest tests/*.py && coverage report -m ./*.py"
+		pgosm /bin/bash -c "cd docker && coverage run -m unittest tests/*.py || true"
+
+	docker exec -it \
+		-e POSTGRES_PASSWORD=mysecretpassword \
+		-e POSTGRES_USER=postgres \
+		-u $(CURRENT_UID):$(CURRENT_GID) \
+		pgosm /bin/bash -c "cd docker && coverage report -m ./*.py"
 
 	# Data import tests
 	docker cp tests \

--- a/docker/db.py
+++ b/docker/db.py
@@ -5,7 +5,6 @@ import os
 import sys
 import subprocess
 import time
-
 import psycopg
 import sh
 
@@ -379,12 +378,12 @@ def pgosm_after_import(flex_path):
     LOGGER.info(f'Post-processing output: \n {output.stderr}')
 
 
-def pgosm_nested_admin_polygons(paths):
+def pgosm_nested_admin_polygons(flex_path):
     """Runs stored procedure to calculate nested admin polygons via psql.
 
     Parameters
     ----------------------
-    paths : dict
+    flex_path : str
     """
     sql_raw = 'CALL osm.build_nested_admin_polygons();'
 
@@ -393,18 +392,16 @@ def pgosm_nested_admin_polygons(paths):
     LOGGER.info('Building nested polygons... (this can take a while)')
     output = subprocess.run(cmds,
                             text=True,
-                            cwd=paths['flex_path'],
+                            cwd=flex_path,
                             check=False,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
     LOGGER.info(f'Nested polygon output: \n {output.stdout}')
 
-
     if output.returncode != 0:
         err_msg = f'Failed to build nested polygons. Return code: {output.returncode}'
         LOGGER.error(err_msg)
         sys.exit(f'{err_msg} - Check the log output for details.')
-
 
 
 def rename_schema(schema_name):

--- a/docker/db.py
+++ b/docker/db.py
@@ -419,20 +419,16 @@ def rename_schema(schema_name):
         cur.execute(sql_raw)
 
 
-def run_pg_dump(export_filename, out_path, data_only, schema_name):
+def run_pg_dump(export_path, data_only, schema_name):
     """Runs pg_dump to save processed data to load into other PostGIS DBs.
 
     Parameters
     ---------------------------
-    export_filename : str
-    out_path : str
+    export_path : str
+        Absolute path to output .sql file
     data_only : bool
     schema_name : str
     """
-    if not os.path.isabs(export_filename):
-        export_path = os.path.join(out_path, export_filename)
-    else:
-        export_path = export_filename
     logger = logging.getLogger('pgosm-flex')
     db_name = 'pgosm'
     conn_string = os.environ['PGOSM_CONN']

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -131,14 +131,15 @@ def run_pgosm_flex(layerset, layerset_path, ram, region, subregion, srid,
                                           pgosm_date,
                                           input_file)
 
+    export_path = get_export_full_path(paths['out_path'], export_filename)
+
     if schema_name != 'osm':
         db.rename_schema(schema_name)
 
     if skip_dump:
         logger.info('Skipping pg_dump')
     else:
-        db.run_pg_dump(export_filename,
-                       out_path=paths['out_path'],
+        db.run_pg_dump(export_path=export_path,
                        data_only=data_only,
                        schema_name=schema_name)
     logger.info('PgOSM Flex complete!')
@@ -308,13 +309,34 @@ def get_export_filename(region, subregion, layerset, pgosm_date, input_file):
     if input_file:
         # Assumes .osm.pbf
         base_name = input_file[:-8]
-        filename = f'{base_name}-{layerset}.sql'
+        filename = f'{base_name}-{layerset}-{pgosm_date}.sql'
     elif subregion is None:
         filename = f'{region}-{layerset}-{pgosm_date}.sql'
     else:
         filename = f'{region}-{subregion}-{layerset}-{pgosm_date}.sql'
 
     return filename
+
+
+def get_export_full_path(out_path, export_filename):
+    """If `export_filename` is an absolute path, `out_path` is not considered.
+
+    Parameters
+    -----------------
+    out_path : str
+    export_filename : str
+
+    Returns
+    -----------------
+    export_path : str
+    """
+
+    if os.path.isabs(export_filename):
+        export_path = export_filename
+    else:
+        export_path = os.path.join(out_path, export_filename)
+
+    return export_path
 
 
 def run_osm2pgsql(osm2pgsql_command, flex_path):

--- a/docker/tests/test_pgosm_flex.py
+++ b/docker/tests/test_pgosm_flex.py
@@ -38,3 +38,49 @@ class PgOSMFlexTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             pgosm_flex.validate_region_inputs(region, subregion, input_file)
+
+    def test_get_export_full_path_returns_expected_str(self):
+        export_filename = 'relative-path'
+        out_path = '/tmp/not/real'
+        expected = f'{out_path}/{export_filename}'
+        result = pgosm_flex.get_export_full_path(out_path, export_filename)
+        self.assertEqual(expected, result)
+
+    def test_get_export_filename_slash_to_dash(self):
+        """Ensure region & subregion have slash "/" changed to dash "-"
+
+        Also tests the filename w/ region & subregion - no need for an additional
+        test covering that behavior.
+        """
+        region = 'north-america/us'
+        subregion = 'not/real'
+        layerset = 'default'
+        pgosm_date = '2021-12-02'
+        input_file = None
+        result = pgosm_flex.get_export_filename(region, subregion, layerset, pgosm_date, input_file)
+        expected = 'north-america-us-not-real-default-2021-12-02.sql'
+        self.assertEqual(expected, result)
+
+    def test_get_export_filename_input_file_defined_overrides_region_subregion(self):
+        region = 'doesnotmatter' # Not setting to None to ensure expected behavior
+        subregion = 'alsodoesnotmatter' # Not setting to None to ensure expected behavior
+        layerset = 'default'
+        pgosm_date = '2021-12-02'
+        input_file = '/my/inputfile.osm.pbf'
+        result = pgosm_flex.get_export_filename(region, subregion, layerset, pgosm_date, input_file)
+        expected = '/my/inputfile-default-2021-12-02.sql'
+        self.assertEqual(expected, result)
+
+    def test_get_export_filename_region_only(self):
+        # Need 4 tests covering this function
+        # Check name when region , no subregion
+        #
+        region = 'north-america'
+        subregion = None
+        layerset = 'default'
+        pgosm_date = '2021-12-02'
+        input_file = None
+        result = pgosm_flex.get_export_filename(region, subregion, layerset, pgosm_date, input_file)
+        expected = 'north-america-default-2021-12-02.sql'
+        self.assertEqual(expected, result)
+

--- a/tests/run-output-tests.sh
+++ b/tests/run-output-tests.sh
@@ -43,7 +43,7 @@ for filename in sql/*.sql; do
 done
 
 if $failed; then
-    echo "One or more tests failed."
+    echo "One or more data output tests failed."
 else
-    echo "Tests completed successfully."
+    echo "Data output tests completed successfully."
 fi


### PR DESCRIPTION
# Details

* More improvements RE #193
* :warning: Change output `.sql` filename to include date - Makes pattern consistent, only affects use with `--input-file`
* Adjust Makefile to continue running coverage & data output tests even when python unit tests fail
