### PR TITLE
Enforce osm2pgsql minimum RAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CURRENT_GID := $(shell id -g)
 TODAY := $(shell date +'%Y-%m-%d')
 INPUT_FILE_NAME=custom_source_file.osm.pbf
 REGION_FILE_NAME=region-dc
+RAM=2
 
 # The docker-exec-default and unit-test targets run last
 # to make unit test results visible at the end.
@@ -66,7 +67,7 @@ docker-exec-default: build-run-docker
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		pgosm python3 docker/pgosm_flex.py  \
 		--layerset=default \
-		--ram=1 \
+		--ram=$(RAM) \
 		--region=north-america/us \
 		--subregion=district-of-columbia
 
@@ -93,7 +94,7 @@ docker-exec-input-file: build-run-docker
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		pgosm python3 docker/pgosm_flex.py  \
 		--layerset=default \
-		--ram=1 \
+		--ram=$(RAM) \
 		--input-file=/app/output/$(INPUT_FILE_NAME)
 
 
@@ -122,7 +123,7 @@ docker-exec-region: build-run-docker
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		pgosm python3 docker/pgosm_flex.py  \
 		--layerset=default \
-		--ram=1 \
+		--ram=$(RAM) \
 		--region=$(REGION_FILE_NAME)
 
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Minimum versions supported:
 * PostGIS 3.0
 * osm2pgsql 1.5.0
 
+## Minimum Hardware
+
+osm2pgsql requires [at least 2 GB RAM](https://osm2pgsql.org/doc/manual.html#main-memory).
+Fast SSD drives are strongly recommended.
+
 
 ## PgOSM via Docker
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=8.0.1
 coverage>=6.1.2
-osm2pgsql-tuner==0.0.3
+osm2pgsql-tuner==0.0.4
 psycopg>=3.0.3
 psycopg-binary>=3.0.3
 sh>=1.14.2


### PR DESCRIPTION
Bump osm2pgsql-tuner version to enforce osm2pgsql's minimum RAM requirement in Docker. See https://github.com/rustprooflabs/osm2pgsql-tuner/issues/17

Add similar notes to README.