### PR TITLE
include aeroway tag

### DIFF
--- a/flex-config/style/infrastructure.lua
+++ b/flex-config/style/infrastructure.lua
@@ -103,7 +103,7 @@ local function get_osm_type_subtype(object)
         osm_type_table['osm_subtype'] = nil
     elseif object.tags.aeroway == 'aerodrome' then
         osm_type_table['osm_type'] = 'aeroway'
-        osm_type_table['osm_subtype'] = object.tags['aeroway']
+        osm_type_table['osm_subtype'] = nil
     else
         osm_type_table['osm_type'] = 'unknown'
         osm_type_table['osm_subtype'] = nil

--- a/flex-config/style/infrastructure.lua
+++ b/flex-config/style/infrastructure.lua
@@ -101,6 +101,9 @@ local function get_osm_type_subtype(object)
     elseif object.tags.utility then
         osm_type_table['osm_type'] = 'utility'
         osm_type_table['osm_subtype'] = nil
+    elseif object.tags.aeroway == 'aerodrome' then
+        osm_type_table['osm_type'] = 'aeroway'
+        osm_type_table['osm_subtype'] = object.tags['aeroway']
     else
         osm_type_table['osm_type'] = 'unknown'
         osm_type_table['osm_subtype'] = nil


### PR DESCRIPTION
Fixed an inconsistency with `infrastructure.lua` which referenced the `aeroways` tag, but did not import any features