### PR TITLE
Support append mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Minimum versions supported:
 
 * Postgres 12
 * PostGIS 3.0
-* osm2pgsql 1.5.0
+* osm2pgsql 1.6.0
 
 ## Minimum Hardware
 
@@ -159,7 +159,6 @@ psql -h localhost -p 5433 -d pgosm -U postgres -c "SELECT COUNT(*) FROM osm.road
 │ 39865 │
 └───────┘
 ```
-
 
 
 

--- a/docs/APPEND-MODE.md
+++ b/docs/APPEND-MODE.md
@@ -1,0 +1,84 @@
+# Running osm2pgsql in append mode
+
+----
+
+> WARNING: The process described here is experimental and details will probably change!
+
+----
+
+## Using manual steps
+
+This page documents differences from [MANUAL-STEPS-RUN.md](MANUAL-STEPS-RUN.md)
+
+
+Setup - Need to use Python venv, osmium is a requirement.  Something like...
+
+```bash
+python -m venv venv && source venv/bin/activate
+cd ~/git/pgosm-flex && pip install -r requirements.txt
+```
+
+
+Run osm2pgsql. Must use `--slim` mode without drop.
+
+
+```bash
+cd pgosm-flex/flex-config
+
+osm2pgsql --output=flex --style=./run.lua \
+    --slim \
+    -d $PGOSM_CONN \
+    ~/pgosm-data/district-of-columbia-latest.osm.pbf
+```
+
+Run the normal post-processing as you normally would.
+
+
+`osm2pgsql-replication` is bundled with osm2pgsql install.
+
+https://osm2pgsql.org/doc/manual.html#keeping-the-database-up-to-date-with-osm2pgsql-replication
+
+
+Initialize replication.
+
+
+```bash
+osm2pgsql-replication init -d $PGOSM_CONN \
+    --osm-file ~/pgosm-data/district-of-columbia-latest.osm.pbf
+```
+
+
+
+Refresh the data.  First clear out data that might violate foreign keys. Packaged
+in convenient procedure.
+
+
+```sql
+CALL osm.append_data_start();
+```
+
+Update the data.
+
+
+```bash
+osm2pgsql-replication update -d $PGOSM_CONN \
+    -- \
+    --output=flex --style=./run.lua \
+    --slim \
+    -d $PGOSM_CONN
+```
+
+Refresh Mat views, rebuilds nested place polygon data.
+
+
+```sql
+CALL osm.append_data_finish();
+```
+
+
+Skip nested:
+
+```sql
+CALL osm.append_data_finish(skip_nested := True);
+```
+

--- a/docs/MANUAL-STEPS-RUN.md
+++ b/docs/MANUAL-STEPS-RUN.md
@@ -214,6 +214,7 @@ The post-processing SQL scripts create a procedure to calculate the nested place
 
 
 ```bash
+psql -d $PGOSM_CONN -c "CALL osm.populate_place_polygon_nested();"
 psql -d $PGOSM_CONN -c "CALL osm.build_nested_admin_polygons();"
 ```
 

--- a/flex-config/sql/pgosm-meta.sql
+++ b/flex-config/sql/pgosm-meta.sql
@@ -51,3 +51,7 @@ CREATE OR REPLACE PROCEDURE osm.append_data_finish(skip_nested BOOLEAN = False)
 
 END $$;
 
+
+COMMENT ON PROCEDURE osm.append_data_start() IS 'Prepares PgOSM Flex database for running osm2pgsql in append mode.  Removes records from place_polygon_nested if they existed.';
+COMMENT ON PROCEDURE osm.append_data_finish() IS 'Finalizes PgOSM Flex after osm2pgsql-replication.  Refreshes materialized view and (optionally) processes the place_polygon_nested data.';
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click>=8.0.1
 coverage>=6.1.2
 osm2pgsql-tuner==0.0.4
+osmium==3.2.0
 psycopg>=3.0.3
 psycopg-binary>=3.0.3
 sh>=1.14.2


### PR DESCRIPTION
# Details

Progresses #211.

Add db functions to support append mode, one to run before osm2pgsql, one to run after.

Documentation written to use the `osm2pgsql-replication`, bundled with osm2pgsql.  Other methods of managing the diff data for updates should work.



