### PR TITLE
Ignore postal_code as a building

### DIFF
--- a/flex-config/style/building.lua
+++ b/flex-config/style/building.lua
@@ -63,6 +63,10 @@ function address_only_building(tags)
         or tags.tourism then
             return false
     end
+    -- postal codes are not buildings but can have an address
+    if tags.boundary == 'postal_code' then
+        return false
+    end
 
     -- Opting to include any addr: tag that was not excluded explicitly above
     --   This might be too wide of a net, but trying to be too picky risks


### PR DESCRIPTION
This is an attempt at fixing #227 

Importing Berlin I found that 3 postal codes did appear as buildings. With this change they are gone (but maybe should also be added to the places).