### PR TITLE
Fix absolute path with `--input-file`

### DIFF
--- a/docker/osm2pgsql_recommendation.py
+++ b/docker/osm2pgsql_recommendation.py
@@ -77,13 +77,8 @@ def get_recommended_script(system_ram_gb, osm_pbf_gb, append, pbf_filename,
                                append=append,
                                ssd=True)
 
-    # FIXME: Currently requires .osm.pbf input. Will block full functionality of #192
-    # Uses basename to work with absolute paths
-    filename_no_ext = os.path.basename(pbf_filename).replace('.osm.pbf', '')
-    LOGGER.debug(f'Filename for osm2pgsql command: {filename_no_ext}')
-
     osm2pgsql_cmd = rec.get_osm2pgsql_command(out_format='api',
-                                              pbf_filename=filename_no_ext)
+                                              pbf_path=pbf_filename)
 
     osm2pgsql_cmd = osm2pgsql_cmd.replace('~/pgosm-data', output_path)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=8.0.1
 coverage>=6.1.2
-osm2pgsql-tuner==0.0.5rc1
+osm2pgsql-tuner==0.0.5rc2
 osmium==3.2.0
 psycopg>=3.0.3
 psycopg-binary>=3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=8.0.1
 coverage>=6.1.2
-osm2pgsql-tuner==0.0.5rc2
+osm2pgsql-tuner==0.0.5
 osmium==3.2.0
 psycopg>=3.0.3
 psycopg-binary>=3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=8.0.1
 coverage>=6.1.2
-osm2pgsql-tuner==0.0.4
+osm2pgsql-tuner==0.0.5rc1
 osmium==3.2.0
 psycopg>=3.0.3
 psycopg-binary>=3.0.3


### PR DESCRIPTION
Fix issue with `--input-file` and absolute paths if not using `/app/output` directory, see #229.

* Updated osm2pgsql-tuner to `0.0.5rc1` :warning: https://github.com/rustprooflabs/osm2pgsql-tuner/pull/22

Initial testing seems to fix the issue, allowing this to work.

```
docker run --name pgosm -d --rm     -v ~/pgosm-data:/customlocation     -v /etc/localtime:/etc/localtime:ro     -e POSTGRES_PASSWORD=$POSTGRES_PASSWORD     -p 5433:5432 -d rustprooflabs/pgosm-flex

docker exec -it     pgosm python3 docker/pgosm_flex.py     --ram=8     --input-file=/customlocation/my-custom.osm.pbf 
```
