### PR TITLE
Manual install luarocks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,13 @@ RUN apt-get update \
         libbz2-dev libpq-dev libproj-dev lua5.2 liblua5.2-dev \
         python3 python3-distutils \
         postgresql-server-dev-14 \
-        curl luarocks \
+        curl unzip \
     && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://luarocks.org/releases/luarocks-3.8.0.tar.gz \
+    && tar zxpf luarocks-3.8.0.tar.gz \
+    && cd luarocks-3.8.0 \
+    && ./configure && make && make install
 
 RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
     && python3 /tmp/get-pip.py \

--- a/docs/MANUAL-STEPS-RUN.md
+++ b/docs/MANUAL-STEPS-RUN.md
@@ -22,10 +22,21 @@ sudo apt install -y \
         libboost-dev libboost-system-dev \
         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
         libbz2-dev libpq-dev libproj-dev lua5.2 liblua5.2-dev \
-        luarocks
+        unzip
 ```
 
-I had to use the `PGSQL_INCDIR` on Ubuntu 20.04 to get it to find the libpq headers.
+LuaRocks is installed from source to ensure the latest version is available. Instructions
+[from luarocks.org](https://luarocks.org/).
+
+
+```bash
+wget https://luarocks.org/releases/luarocks-3.8.0.tar.gz
+tar zxpf luarocks-3.8.0.tar.gz
+cd luarocks-3.8.0
+./configure && make && sudo make install
+```
+
+Use `luarocks` to install `inifile` and `luasql-postgres`.
 
 
 ```bash
@@ -33,7 +44,9 @@ sudo luarocks install inifile
 sudo luarocks install luasql-postgres PGSQL_INCDIR=/usr/include/postgresql/
 ```
 
-Install osm2pgsql from source.
+Install osm2pgsql from source.  The version from `apt install` is unlikely to be new enough
+for use with this project.
+
 
 ```bash
 git clone git://github.com/openstreetmap/osm2pgsql.git
@@ -313,21 +326,6 @@ the latest documented functionality.
 * Does the database user have proper [permissisions in Postgres](POSTGRES-PERMISSIONS.md)?
 
 
-### Luarocks not installed properly
-
-This problem results in the error message `'luasql.postgres' not found`.
-An example of this issue is reported [via #218](https://github.com/rustprooflabs/pgosm-flex/issues/218).
-
-May need to install LuaRocks from source package, instructions
-[from luarocks.org](https://luarocks.org/).
-
-
-```bash
-wget https://luarocks.org/releases/luarocks-3.8.0.tar.gz
-tar zxpf luarocks-3.8.0.tar.gz
-cd luarocks-3.8.0
-./configure && make && sudo make install
-```
 
 ### Too many Postgres connections
 


### PR DESCRIPTION
Issue with older luarocks installed by `apt install luarocks`.  Resulted in v2.4.0 (circa 2016?) installed.  Failure from still using the unsecure `git://` protocol.  Using method documented in #218 hoping it fixes the issue.

https://github.com/rustprooflabs/pgosm-flex/runs/5684687464?check_suite_focus=true

```
 > [ 5/11] RUN luarocks install luasql-postgres PGSQL_INCDIR=/usr/include/postgresql/:
#9 1.124 Installing https://luarocks.org/luasql-postgres-2.6.0-1.rockspec
#9 1.438 Cloning into 'luasql'...
#9 1.545 fatal: remote error: 
#9 1.545   The unauthenticated git protocol on port 9418 is no longer supported.
#9 1.545 Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
#9 1.547 
#9 1.547 Error: Failed cloning git repository.
------
error: failed to solve: executor failed running [/bin/sh -c luarocks install luasql-postgres PGSQL_INCDIR=/usr/include/postgresql/]: exit code: 1
Error: buildx failed with: error: failed to solve: executor failed running [/bin/sh -c luarocks install luasql-postgres PGSQL_INCDIR=/usr/include/postgresql/]: exit code: 1
```