### PR TITLE
Bump requirements versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-click>=8.0.1
-coverage>=6.1.2
+click>=8.1.3
+coverage>=6.4.1
 osm2pgsql-tuner==0.0.5
-osmium==3.2.0
-psycopg>=3.0.3
-psycopg-binary>=3.0.3
+osmium==3.3.0
+psycopg>=3.0.15
+psycopg-binary>=3.0.15
 sh>=1.14.2


### PR DESCRIPTION
Main change was to bump [osmium to v3.3.0](https://github.com/osmcode/pyosmium/releases/tag/v3.3.0). Other requirements were defined w/ >= and just bumped to the versions installed in the latest Docker image.

