### PR TITLE
Improve relation handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ docker-exec-default: build-run-docker
 		-e POSTGRES_USER=postgres \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		pgosm python3 docker/pgosm_flex.py  \
-		--layerset=default \
+		--layerset=everything \
 		--ram=$(RAM) \
 		--region=north-america/us \
 		--subregion=district-of-columbia

--- a/flex-config/sql/place.sql
+++ b/flex-config/sql/place.sql
@@ -49,7 +49,7 @@ CREATE INDEX ix_osm_place_line_type ON osm.place_line (osm_type);
 CREATE INDEX ix_osm_place_polygon_type ON osm.place_polygon (osm_type);
 
 
-CREATE VIEW osm.places_in_relations AS
+CREATE VIEW osm.place_polygon_in_relations AS
 SELECT p_no_rel.osm_id
     FROM osm.place_polygon p_no_rel
     WHERE osm_id > 0
@@ -63,8 +63,8 @@ SELECT p_no_rel.osm_id
             ) 
 ;
 
-COMMENT ON VIEW osm.places_in_relations IS 'Lists all osm_id values included in a relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
-COMMENT ON COLUMN osm.places_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
+COMMENT ON VIEW osm.place_polygon_in_relations IS 'Lists all osm_id values included in a place_polygon relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
+COMMENT ON COLUMN osm.place_polygon_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
 
 
 CREATE MATERIALIZED VIEW osm.vplace_polygon AS
@@ -72,7 +72,7 @@ SELECT p.*
     FROM osm.place_polygon p
     WHERE NOT EXISTS (
         SELECT 1 
-            FROM osm.places_in_relations pir 
+            FROM osm.place_polygon_in_relations pir
             WHERE p.osm_id = pir.osm_id)
 ;
 
@@ -83,7 +83,7 @@ CREATE INDEX gix_osm_vplace_polygon
 
 
 
-COMMENT ON MATERIALIZED VIEW osm.vplace_polygon IS 'Simplified polygon layer removing non-relation geometries when a relation contains it in the member_ids column.';
+COMMENT ON MATERIALIZED VIEW osm.vplace_polygon IS 'Simplified place polygon layer removing non-relation geometries when a relation contains it in the member_ids column.';
 COMMENT ON COLUMN osm.vplace_polygon.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
 COMMENT ON COLUMN osm.vplace_polygon.osm_type IS 'Values from place if a place tag exists.  If no place tag, values boundary or admin_level indicate the source of the feature.';
 COMMENT ON COLUMN osm.vplace_polygon.member_ids IS 'Member IDs making up the full relation.  NULL if not a relation.  Used to create improved osm.vplace_polygon.';

--- a/flex-config/sql/public_transport.sql
+++ b/flex-config/sql/public_transport.sql
@@ -66,3 +66,76 @@ COMMENT ON COLUMN osm.public_transport_point.network IS 'Route, system or operat
 COMMENT ON COLUMN osm.public_transport_line.network IS 'Route, system or operator. Usage of network key is widely varied. See https://wiki.openstreetmap.org/wiki/Key:network';
 COMMENT ON COLUMN osm.public_transport_polygon.network IS 'Route, system or operator. Usage of network key is widely varied. See https://wiki.openstreetmap.org/wiki/Key:network';
 
+
+
+
+------------------------------------------------
+
+CREATE VIEW osm.public_transport_polygon_in_relations AS
+SELECT p_no_rel.osm_id
+    FROM osm.public_transport_polygon p_no_rel
+    WHERE osm_id > 0
+        AND EXISTS (SELECT * 
+            FROM (SELECT i.osm_id AS relation_id, 
+                        jsonb_array_elements_text(i.member_ids)::BIGINT AS member_id
+                    FROM osm.public_transport_polygon i
+                    WHERE i.osm_id < 0
+                    ) rel
+            WHERE rel.member_id = p_no_rel.osm_id
+            ) 
+;
+
+COMMENT ON VIEW osm.public_transport_polygon_in_relations IS 'Lists all osm_id values included in a public_transport_polygon relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
+COMMENT ON COLUMN osm.public_transport_polygon_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
+
+
+CREATE MATERIALIZED VIEW osm.vpublic_transport_polygon AS
+SELECT p.*
+    FROM osm.public_transport_polygon p
+    WHERE NOT EXISTS (
+        SELECT 1 
+            FROM osm.public_transport_polygon_in_relations pir
+            WHERE p.osm_id = pir.osm_id)
+;
+
+CREATE UNIQUE INDEX uix_osm_vpublic_transport_polygon_osm_id
+    ON osm.vpublic_transport_polygon (osm_id);
+CREATE INDEX gix_osm_vpublic_transport_polygon
+    ON osm.vpublic_transport_polygon USING GIST (geom);
+
+
+
+------------------------------------------------
+
+CREATE VIEW osm.public_transport_line_in_relations AS
+SELECT p_no_rel.osm_id
+    FROM osm.public_transport_line p_no_rel
+    WHERE osm_id > 0
+        AND EXISTS (SELECT * 
+            FROM (SELECT i.osm_id AS relation_id, 
+                        jsonb_array_elements_text(i.member_ids)::BIGINT AS member_id
+                    FROM osm.public_transport_line i
+                    WHERE i.osm_id < 0
+                    ) rel
+            WHERE rel.member_id = p_no_rel.osm_id
+            ) 
+;
+
+COMMENT ON VIEW osm.public_transport_line_in_relations IS 'Lists all osm_id values included in a public_transport_line relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
+COMMENT ON COLUMN osm.public_transport_line_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
+
+
+CREATE MATERIALIZED VIEW osm.vpublic_transport_line AS
+SELECT p.*
+    FROM osm.public_transport_line p
+    WHERE NOT EXISTS (
+        SELECT 1 
+            FROM osm.public_transport_line_in_relations pir
+            WHERE p.osm_id = pir.osm_id)
+;
+
+CREATE UNIQUE INDEX uix_osm_vpublic_transport_line_osm_id
+    ON osm.vpublic_transport_line (osm_id);
+CREATE INDEX gix_osm_vpublic_transport_line
+    ON osm.vpublic_transport_line USING GIST (geom);
+

--- a/flex-config/sql/road.sql
+++ b/flex-config/sql/road.sql
@@ -54,3 +54,77 @@ CREATE INDEX ix_osm_road_line_highway ON osm.road_line (osm_type);
 CREATE INDEX ix_osm_road_line_major
     ON osm.road_line (major)
     WHERE major;
+
+
+
+------------------------------------------------
+
+CREATE VIEW osm.road_polygon_in_relations AS
+SELECT p_no_rel.osm_id
+    FROM osm.road_polygon p_no_rel
+    WHERE osm_id > 0
+        AND EXISTS (SELECT * 
+            FROM (SELECT i.osm_id AS relation_id, 
+                        jsonb_array_elements_text(i.member_ids)::BIGINT AS member_id
+                    FROM osm.road_polygon i
+                    WHERE i.osm_id < 0
+                    ) rel
+            WHERE rel.member_id = p_no_rel.osm_id
+            ) 
+;
+
+COMMENT ON VIEW osm.road_polygon_in_relations IS 'Lists all osm_id values included in a road_polygon relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
+COMMENT ON COLUMN osm.road_polygon_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
+
+
+CREATE MATERIALIZED VIEW osm.vroad_polygon AS
+SELECT p.*
+    FROM osm.road_polygon p
+    WHERE NOT EXISTS (
+        SELECT 1 
+            FROM osm.road_polygon_in_relations pir
+            WHERE p.osm_id = pir.osm_id)
+;
+
+CREATE UNIQUE INDEX uix_osm_vroad_polygon_osm_id
+    ON osm.vroad_polygon (osm_id);
+CREATE INDEX gix_osm_vroad_polygon
+    ON osm.vroad_polygon USING GIST (geom);
+
+
+
+------------------------------------------------
+
+CREATE VIEW osm.road_line_in_relations AS
+SELECT p_no_rel.osm_id
+    FROM osm.road_line p_no_rel
+    WHERE osm_id > 0
+        AND EXISTS (SELECT * 
+            FROM (SELECT i.osm_id AS relation_id, 
+                        jsonb_array_elements_text(i.member_ids)::BIGINT AS member_id
+                    FROM osm.road_line i
+                    WHERE i.osm_id < 0
+                    ) rel
+            WHERE rel.member_id = p_no_rel.osm_id
+            ) 
+;
+
+COMMENT ON VIEW osm.road_line_in_relations IS 'Lists all osm_id values included in a road_line relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
+COMMENT ON COLUMN osm.road_line_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
+
+
+CREATE MATERIALIZED VIEW osm.vroad_line AS
+SELECT p.*
+    FROM osm.road_line p
+    WHERE NOT EXISTS (
+        SELECT 1 
+            FROM osm.road_line_in_relations pir
+            WHERE p.osm_id = pir.osm_id)
+;
+
+CREATE UNIQUE INDEX uix_osm_vroad_line_osm_id
+    ON osm.vroad_line (osm_id);
+CREATE INDEX gix_osm_vroad_line
+    ON osm.vroad_line USING GIST (geom);
+
+

--- a/flex-config/sql/road_major.sql
+++ b/flex-config/sql/road_major.sql
@@ -20,3 +20,42 @@ ALTER TABLE osm.road_major
 ;
 
 CREATE INDEX ix_osm_road_major_type ON osm.road_major (osm_type);
+
+
+
+
+------------------------------------------------
+
+CREATE VIEW osm.road_major_in_relations AS
+SELECT p_no_rel.osm_id
+    FROM osm.road_major p_no_rel
+    WHERE osm_id > 0
+        AND EXISTS (SELECT * 
+            FROM (SELECT i.osm_id AS relation_id, 
+                        jsonb_array_elements_text(i.member_ids)::BIGINT AS member_id
+                    FROM osm.road_major i
+                    WHERE i.osm_id < 0
+                    ) rel
+            WHERE rel.member_id = p_no_rel.osm_id
+            ) 
+;
+
+COMMENT ON VIEW osm.road_major_in_relations IS 'Lists all osm_id values included in a road_major relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
+COMMENT ON COLUMN osm.road_major_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
+
+
+CREATE MATERIALIZED VIEW osm.vroad_major AS
+SELECT p.*
+    FROM osm.road_major p
+    WHERE NOT EXISTS (
+        SELECT 1 
+            FROM osm.road_major_in_relations pir
+            WHERE p.osm_id = pir.osm_id)
+;
+
+CREATE UNIQUE INDEX uix_osm_vroad_major_osm_id
+    ON osm.vroad_major (osm_id);
+CREATE INDEX gix_osm_vroad_major
+    ON osm.vroad_major USING GIST (geom);
+
+

--- a/flex-config/sql/water.sql
+++ b/flex-config/sql/water.sql
@@ -52,9 +52,80 @@ ALTER TABLE osm.water_polygon
     PRIMARY KEY (osm_id)
 ;
 
-
 -- osm_type column only has natural/waterway values.
 -- Indexing osm_subtype b/c has more selective and seems more likely to be used.
 CREATE INDEX ix_osm_water_point_type ON osm.water_point (osm_subtype);
 CREATE INDEX ix_osm_water_line_type ON osm.water_line (osm_subtype);
 CREATE INDEX ix_osm_water_polygon_type ON osm.water_polygon (osm_subtype);
+
+
+------------------------------------------------
+
+CREATE VIEW osm.water_polygon_in_relations AS
+SELECT p_no_rel.osm_id
+    FROM osm.water_polygon p_no_rel
+    WHERE osm_id > 0
+        AND EXISTS (SELECT * 
+            FROM (SELECT i.osm_id AS relation_id, 
+                        jsonb_array_elements_text(i.member_ids)::BIGINT AS member_id
+                    FROM osm.water_polygon i
+                    WHERE i.osm_id < 0
+                    ) rel
+            WHERE rel.member_id = p_no_rel.osm_id
+            ) 
+;
+
+COMMENT ON VIEW osm.water_polygon_in_relations IS 'Lists all osm_id values included in a water_polygon relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
+COMMENT ON COLUMN osm.water_polygon_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
+
+
+CREATE MATERIALIZED VIEW osm.vwater_polygon AS
+SELECT p.*
+    FROM osm.water_polygon p
+    WHERE NOT EXISTS (
+        SELECT 1 
+            FROM osm.water_polygon_in_relations pir
+            WHERE p.osm_id = pir.osm_id)
+;
+
+CREATE UNIQUE INDEX uix_osm_vwater_polygon_osm_id
+    ON osm.vwater_polygon (osm_id);
+CREATE INDEX gix_osm_vwater_polygon
+    ON osm.vwater_polygon USING GIST (geom);
+
+
+
+------------------------------------------------
+
+CREATE VIEW osm.water_line_in_relations AS
+SELECT p_no_rel.osm_id
+    FROM osm.water_line p_no_rel
+    WHERE osm_id > 0
+        AND EXISTS (SELECT * 
+            FROM (SELECT i.osm_id AS relation_id, 
+                        jsonb_array_elements_text(i.member_ids)::BIGINT AS member_id
+                    FROM osm.water_line i
+                    WHERE i.osm_id < 0
+                    ) rel
+            WHERE rel.member_id = p_no_rel.osm_id
+            ) 
+;
+
+COMMENT ON VIEW osm.water_line_in_relations IS 'Lists all osm_id values included in a water_line relation''s member_ids list.  Technically could contain duplicates, but not a concern with current expected use of this view.';
+COMMENT ON COLUMN osm.water_line_in_relations.osm_id IS 'OpenStreetMap ID. Unique along with geometry type.';
+
+
+CREATE MATERIALIZED VIEW osm.vwater_line AS
+SELECT p.*
+    FROM osm.water_line p
+    WHERE NOT EXISTS (
+        SELECT 1 
+            FROM osm.water_line_in_relations pir
+            WHERE p.osm_id = pir.osm_id)
+;
+
+CREATE UNIQUE INDEX uix_osm_vwater_line_osm_id
+    ON osm.vwater_line (osm_id);
+CREATE INDEX gix_osm_vwater_line
+    ON osm.vwater_line USING GIST (geom);
+

--- a/flex-config/style/public_transport.lua
+++ b/flex-config/style/public_transport.lua
@@ -48,6 +48,7 @@ tables.public_transport_line = osm2pgsql.define_table({
         { column = 'lit',     type = 'text' },
         { column = 'wheelchair', type = 'text'},
         { column = 'wheelchair_desc', type = 'text'},
+        { column = 'member_ids', type = 'jsonb'},
         { column = 'geom',     type = 'multilinestring', projection = srid }
     }
 })
@@ -73,6 +74,7 @@ tables.public_transport_polygon = osm2pgsql.define_table({
         { column = 'lit',     type = 'text' },
         { column = 'wheelchair', type = 'text'},
         { column = 'wheelchair_desc', type = 'text'},
+        { column = 'member_ids', type = 'jsonb'},
         { column = 'geom',     type = 'multipolygon', projection = srid }
     }
 })
@@ -246,12 +248,12 @@ local function public_transport_process_way(object)
 end
 
 
-
 function public_transport_process_relation(object)
     if not is_first_level_public_transport(object.tags) then
         return
     end
 
+    local member_ids = osm2pgsql.way_member_ids(object)
     local osm_types = get_osm_type_subtype(object)
 
     local public_transport = object.tags.public_transport
@@ -290,6 +292,7 @@ function public_transport_process_relation(object)
             lit = lit,
             wheelchair = wheelchair,
             wheelchair_desc = wheelchair_desc,
+            member_ids = member_ids,
             geom = { create = 'area' }
         })
     else
@@ -309,6 +312,7 @@ function public_transport_process_relation(object)
             lit = lit,
             wheelchair = wheelchair,
             wheelchair_desc = wheelchair_desc,
+            member_ids = member_ids,
             geom = { create = 'line' }
         })
     end

--- a/flex-config/style/road.lua
+++ b/flex-config/style/road.lua
@@ -40,6 +40,7 @@ tables.road_line = osm2pgsql.define_table({
         { column = 'route_cycle',     type = 'boolean' },
         { column = 'route_motor',     type = 'boolean' },
         { column = 'access',     type = 'text' },
+        { column = 'member_ids', type = 'jsonb'},
         { column = 'geom',     type = 'multilinestring', projection = srid }
     }
 })
@@ -62,6 +63,7 @@ tables.road_polygon = osm2pgsql.define_table({
         { column = 'route_cycle',     type = 'boolean' },
         { column = 'route_motor',     type = 'boolean' },
         { column = 'access',     type = 'text' },
+        { column = 'member_ids', type = 'jsonb'},
         { column = 'geom',     type = 'multipolygon', projection = srid }
     }
 })
@@ -173,6 +175,8 @@ function road_process_relation(object)
         return
     end
 
+    local member_ids = osm2pgsql.way_member_ids(object)
+
     local name = get_name(object.tags)
     local route_foot = routable_foot(object.tags)
     local route_cycle = routable_cycle(object.tags)
@@ -209,6 +213,7 @@ function road_process_relation(object)
             route_cycle = route_cycle,
             route_motor = route_motor,
             access = access,
+            member_ids = member_ids,
             geom = { create = 'area' }
         })
     else
@@ -226,6 +231,7 @@ function road_process_relation(object)
             route_cycle = route_cycle,
             route_motor = route_motor,
             access = access,
+            member_ids = member_ids,
             geom = { create = 'line' }
         })
     end

--- a/flex-config/style/road_major.lua
+++ b/flex-config/style/road_major.lua
@@ -15,6 +15,7 @@ tables.road_major = osm2pgsql.define_table({
         { column = 'tunnel',     type = 'text' },
         { column = 'bridge',     type = 'text' },
         { column = 'major',   type = 'boolean', not_null = true},
+        { column = 'member_ids', type = 'jsonb'},
         { column = 'geom',     type = 'multilinestring', projection = srid },
     }
 })
@@ -65,6 +66,8 @@ function road_major_process_relation(object)
         return
     end
 
+    local member_ids = osm2pgsql.way_member_ids(object)
+
     local major = true
 
     local name = get_name(object.tags)
@@ -91,6 +94,7 @@ function road_major_process_relation(object)
         layer = layer,
         tunnel = tunnel,
         bridge = bridge,
+        member_ids = member_ids,
         geom = { create = 'line' }
     })
 

--- a/flex-config/style/water.lua
+++ b/flex-config/style/water.lua
@@ -31,6 +31,7 @@ tables.water_line = osm2pgsql.define_table({
         { column = 'tunnel',     type = 'text' },
         { column = 'bridge',     type = 'text' },
         { column = 'boat',     type = 'text' },
+        { column = 'member_ids', type = 'jsonb'},
         { column = 'geom',     type = 'multilinestring' , projection = srid},
     }
 })
@@ -48,6 +49,7 @@ tables.water_polygon = osm2pgsql.define_table({
         { column = 'tunnel',     type = 'text' },
         { column = 'bridge',     type = 'text' },
         { column = 'boat',     type = 'text' },
+        { column = 'member_ids', type = 'jsonb'},
         { column = 'geom',     type = 'multipolygon' , projection = srid},
     }
 })
@@ -206,6 +208,8 @@ function water_process_relation(object)
         return
     end
 
+    local member_ids = osm2pgsql.way_member_ids(object)
+
     if object.tags.natural == 'water'
             or object.tags.natural == 'lake'
             or object.tags.natural == 'hot_spring'
@@ -233,6 +237,7 @@ function water_process_relation(object)
                 tunnel = tunnel,
                 bridge = bridge,
                 boat = boat,
+                member_ids = member_ids,
                 geom = { create = 'area' }
             })
         else
@@ -244,6 +249,7 @@ function water_process_relation(object)
                 tunnel = tunnel,
                 bridge = bridge,
                 boat = boat,
+                member_ids = member_ids,
                 geom = { create = 'line' }
             })
         end
@@ -266,6 +272,7 @@ function water_process_relation(object)
                 tunnel = tunnel,
                 bridge = bridge,
                 boat = boat,
+                member_ids = member_ids,
                 geom = { create = 'area' }
             })
         else
@@ -277,6 +284,7 @@ function water_process_relation(object)
                 tunnel = tunnel,
                 bridge = bridge,
                 boat = boat,
+                member_ids = member_ids,
                 geom = { create = 'line' }
             })
         end


### PR DESCRIPTION
Closes https://github.com/rustprooflabs/pgosm-flex/issues/255.

### :warning: Potentially breaking change

My intention of this particular view isn't for it to be queried directly, but that doesn't mean someone somewhere isn't.  This is the reason for bumping version to 0.6.0 instead of continuing with 0.5.2.

* Rename backend view `places_in_relations` to `place_polygon_in_relations` https://github.com/rustprooflabs/pgosm-flex/commit/5a57c5eef03054aaafa285b0d2d6dbc878bfa1ce

### New materialized views

New views to be preferred by default over the base table name (w/out `v` in the name).

* `osm.vroad_line`
* `osm.vroad_polygon`
* `osm.vroad_major`
* `osm.vwater_line`
* `osm.vwater_polygon`
* `osm.vpublic_transport_line`
* `osm.vpublic_transport_polygon`

### New backend views

The materialized views all have related views used.  Not listed here, not expected to be primary use views.