### PR TITLE
Adjust Dockerfile to use PostGIS 3.3 instead of master branch that uses 3.4-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:15-master
+FROM postgis/postgis:15-3.3
 
 LABEL maintainer="PgOSM Flex - https://github.com/rustprooflabs/pgosm-flex"
 


### PR DESCRIPTION
# Details

I just noticed that when I changed the Docker image for Pg15 (#260) I accidentally set this project to use PostGIS 3.4-dev instead of PostGIS 3.3.  This change pins to the 3.3 version for stability.