### PR TITLE
Internally rename append to replication

### DIFF
--- a/docker/db.py
+++ b/docker/db.py
@@ -181,20 +181,20 @@ def pg_isready():
     return True
 
 
-def prepare_pgosm_db(data_only, db_path, append):
+def prepare_pgosm_db(data_only, db_path, replication):
     """Runs through series of steps to prepare database for PgOSM.
 
     Parameters
     --------------------------
     data_only : bool
     db_path : str
-    append : bool
+    replication : bool
     """
 
     if pg_conn_parts()['pg_host'] == 'localhost':
         LOGGER.debug('Running standard database prep for in-Docker operation. Includes DROP/CREATE DATABASE')
-        if append:
-            LOGGER.debug('Skipping DB drop b/c of append mode')
+        if replication:
+            LOGGER.debug('Skipping DB drop b/c of append (osm2pgsql-replication) mode')
         else:
             LOGGER.debug('Dropping database')
             drop_pgosm_db()
@@ -505,6 +505,7 @@ def osm2pgsql_replication_start():
     """Runs pre-replication step to clean out FKs that would prevent updates.
     """
     LOGGER.info('Prep database to allow data updates.')
+    # This use of append applies to both osm2pgsql --append and osm2pgsq-replication, not renaming from "append"
     sql_raw = 'CALL osm.append_data_start();'
 
     with get_db_conn(conn_string=connection_string()) as conn:

--- a/docker/osm2pgsql_recommendation.py
+++ b/docker/osm2pgsql_recommendation.py
@@ -70,10 +70,10 @@ def get_recommended_script(system_ram_gb, osm_pbf_gb, replication, pbf_filename,
     """
     LOGGER.debug('Generating recommended osm2pgsql command')
 
+   # This function call will change as this is implemented
+   # https://github.com/rustprooflabs/osm2pgsql-tuner/issues/24
     rec = tuner.recommendation(system_ram_gb=system_ram_gb,
                                osm_pbf_gb=osm_pbf_gb,
-                               # This will change as this is implemented
-                               # https://github.com/rustprooflabs/osm2pgsql-tuner/issues/24
                                append=replication,
                                ssd=True)
 

--- a/docker/osm2pgsql_recommendation.py
+++ b/docker/osm2pgsql_recommendation.py
@@ -10,21 +10,19 @@ import db
 LOGGER = logging.getLogger('pgosm-flex')
 
 
-def osm2pgsql_recommendation(ram, pbf_filename, out_path, append):
+def osm2pgsql_recommendation(ram, pbf_filename, out_path, replication):
     """Returns recommended osm2pgsql command.
 
-    Recommendation from API at https://osm2pgsql-tuner.com
+    Recommendation from Python project.
+    Public API available at https://osm2pgsql-tuner.com
 
     Parameters
     ----------------------
     ram : float
         Total system RAM available in GB
-
     pbf_filename : str
-
     out_path : str
-
-    append : boolean
+    replication : boolean
 
     Returns
     ----------------------
@@ -42,12 +40,12 @@ def osm2pgsql_recommendation(ram, pbf_filename, out_path, append):
 
     osm2pgsql_cmd = get_recommended_script(system_ram_gb,
                                            osm_pbf_gb,
-                                           append,
+                                           replication,
                                            pbf_file,
                                            out_path)
     return osm2pgsql_cmd
 
-def get_recommended_script(system_ram_gb, osm_pbf_gb, append, pbf_filename,
+def get_recommended_script(system_ram_gb, osm_pbf_gb, replication, pbf_filename,
                            output_path):
     """Generates recommended osm2pgsql command from osm2pgsql-tuner.
 
@@ -55,7 +53,7 @@ def get_recommended_script(system_ram_gb, osm_pbf_gb, append, pbf_filename,
     -------------------------------
     system_ram_gb : float
     osm_pbf_gb : float
-    append : bool
+    replication : bool
     pbf_filename : str
         Can be filename or absolute path.
     output_path : str
@@ -74,7 +72,9 @@ def get_recommended_script(system_ram_gb, osm_pbf_gb, append, pbf_filename,
 
     rec = tuner.recommendation(system_ram_gb=system_ram_gb,
                                osm_pbf_gb=osm_pbf_gb,
-                               append=append,
+                               # This will change as this is implemented
+                               # https://github.com/rustprooflabs/osm2pgsql-tuner/issues/24
+                               append=replication,
                                ssd=True)
 
     osm2pgsql_cmd = rec.get_osm2pgsql_command(out_format='api',

--- a/docs/DOCKER-RUN.md
+++ b/docs/DOCKER-RUN.md
@@ -135,6 +135,11 @@ Options:
                         --input-file is specified, otherwise required.
   --subregion TEXT      Sub-region name matching the filename for data sourced
                         from Geofabrik. e.g. district-of-columbia
+  --append              EXPERIMENTAL - Append mode enables updates via
+                        osm2pgsql-replication. This functionality will be
+                        renamed to --replication in future versions of PgOSM
+                        Flex. Details: https://github.com/rustprooflabs/pgosm-
+                        flex/issues/275
   --data-only           When set, skips running Sqitch and importing QGIS
                         Styles.
   --debug               Enables additional log output


### PR DESCRIPTION
Internally renaming `append` variable to `replication`. No functional changes.  This renames variables to set stage for coming changes, documents a few details, and generally makes it more clear osm2pgsql-tuner is being used, not a wrapper around `osm2pgsql --append` as it would appear.

Sets stage for changes outlined in https://github.com/rustprooflabs/pgosm-flex/issues/275#issuecomment-1340362190