### PR TITLE
Allow SP-GIST indexes

### DIFF
--- a/docker/helpers.py
+++ b/docker/helpers.py
@@ -82,7 +82,7 @@ def verify_checksum(md5_file, path):
 
 
 def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
-                 layerset_path):
+                 layerset_path, sp_gist):
     """Sets environment variables needed by PgOSM Flex.
 
     See /docs/MANUAL-STEPS-RUN.md for usage examples of environment variables.
@@ -97,6 +97,8 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
     layerset : str
     layerset_path : str
         str when set, or None
+    sp_gist : bool
+        When `True` uses SP-GIST index instead of GIST for spatial indexes.
     """
     logger = logging.getLogger('pgosm-flex')
     logger.debug('Ensuring env vars are not set from prior run')
@@ -134,6 +136,11 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
     # Connection to DB for admin purposes, e.g. drop/create main database
     os.environ['PGOSM_CONN_PG'] = db.connection_string(admin=True)
 
+    if sp_gist:
+        os.environ['PGOSM_GIST_TYPE'] = 'spgist'
+    else:
+        os.environ['PGOSM_GIST_TYPE'] = 'gist'
+
 
 def unset_env_vars():
     """Unsets environment variables used by PgOSM Flex.
@@ -150,3 +157,4 @@ def unset_env_vars():
     os.environ.pop('PGOSM_LAYERSET', None)
     os.environ.pop('PGOSM_CONN', None)
     os.environ.pop('PGOSM_CONN_PG', None)
+    os.environ.pop('PGOSM_GIST_TYPE', None)

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -69,9 +69,11 @@ import helpers
 @click.option('--srid', required=False, default=helpers.DEFAULT_SRID,
               envvar="PGOSM_SRID",
               help="SRID for data loaded by osm2pgsql to PostGIS. Defaults to 3857")
+@click.option('--sp-gist', default=False, is_flag=True,
+              help='When set, builds SP-GIST indexes on geom column instead of the default GIST indexes.')
 def run_pgosm_flex(ram, region, subregion, append, data_only, debug,
                     input_file, layerset, layerset_path, language, pgosm_date,
-                    schema_name, skip_dump, skip_nested, srid):
+                    schema_name, skip_dump, skip_nested, srid, sp_gist):
     """Run PgOSM Flex within Docker to automate osm2pgsql flex processing.
     """
     paths = get_paths()
@@ -96,7 +98,7 @@ def run_pgosm_flex(ram, region, subregion, append, data_only, debug,
         region = input_file
 
     helpers.set_env_vars(region, subregion, srid, language, pgosm_date,
-                         layerset, layerset_path)
+                         layerset, layerset_path, sp_gist)
     db.wait_for_postgres()
     db.prepare_pgosm_db(data_only=data_only,
                         db_path=paths['db_path'],

--- a/docs/DOCKER-RUN.md
+++ b/docs/DOCKER-RUN.md
@@ -165,6 +165,8 @@ Options:
                         be time consuming on large regions.
   --srid TEXT           SRID for data loaded by osm2pgsql to PostGIS. Defaults
                         to 3857
+  --sp-gist             When set, builds SP-GIST indexes on geom column
+                        instead of the default GIST indexes.
   --help                Show this message and exit.
 ```
 

--- a/flex-config/helpers.lua
+++ b/flex-config/helpers.lua
@@ -43,6 +43,19 @@ else
 end
 
 
+local gist_type_env = os.getenv("PGOSM_GIST_TYPE")
+if gist_type_env then
+    gist_type = gist_type_env
+else
+    gist_type = 'gist'
+end
+
+if gist_type ~= 'gist' and gist_type ~= 'spgist' then
+    error('Invalid PGOSM_GIST_TYPE.  Must be gist or spgist. Value: ' .. gist_type)
+end
+print('Spatial index type: ' .. gist_type)
+
+
 -- Best way to change schema name is post-processing.
 -- Use ALTER SCHEMA osm RENAME TO your_schema;
 schema_name = 'osm'

--- a/flex-config/style/amenity.lua
+++ b/flex-config/style/amenity.lua
@@ -21,7 +21,7 @@ tables.amenity_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }
@@ -46,7 +46,7 @@ tables.amenity_line = osm2pgsql.define_table({
         { column = 'geom', type = 'linestring', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }
@@ -72,7 +72,7 @@ tables.amenity_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }

--- a/flex-config/style/building.lua
+++ b/flex-config/style/building.lua
@@ -25,7 +25,7 @@ tables.building_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }
@@ -54,7 +54,7 @@ tables.building_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }

--- a/flex-config/style/indoor.lua
+++ b/flex-config/style/indoor.lua
@@ -19,7 +19,7 @@ tables.indoor_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point' , projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })
@@ -42,7 +42,7 @@ tables.indoor_line = osm2pgsql.define_table({
         { column = 'geom', type = 'linestring', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })
@@ -65,7 +65,7 @@ tables.indoor_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon' , projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })

--- a/flex-config/style/infrastructure.lua
+++ b/flex-config/style/infrastructure.lua
@@ -30,7 +30,7 @@ tables.infrastructure_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }
@@ -51,7 +51,7 @@ tables.infrastructure_line = osm2pgsql.define_table({
         { column = 'geom', type = 'linestring', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }
@@ -73,7 +73,7 @@ tables.infrastructure_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }

--- a/flex-config/style/landuse.lua
+++ b/flex-config/style/landuse.lua
@@ -13,7 +13,7 @@ tables.landuse_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })
@@ -29,7 +29,7 @@ tables.landuse_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })

--- a/flex-config/style/leisure.lua
+++ b/flex-config/style/leisure.lua
@@ -13,7 +13,7 @@ tables.leisure_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })
@@ -29,7 +29,7 @@ tables.leisure_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })

--- a/flex-config/style/natural.lua
+++ b/flex-config/style/natural.lua
@@ -14,7 +14,7 @@ tables.natural_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })
@@ -31,7 +31,7 @@ tables.natural_line = osm2pgsql.define_table({
         { column = 'geom', type = 'linestring' , projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })
@@ -48,7 +48,7 @@ tables.natural_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon' , projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
     }
 })

--- a/flex-config/style/place.lua
+++ b/flex-config/style/place.lua
@@ -15,7 +15,7 @@ tables.place_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'boundary', method = 'btree', where = 'boundary IS NOT NULL ' },
         { column = 'admin_level', method = 'btree', where = 'admin_level IS NOT NULL ' },
@@ -35,7 +35,7 @@ tables.place_line = osm2pgsql.define_table({
         { column = 'geom', type = 'linestring', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'boundary', method = 'btree', where = 'boundary IS NOT NULL ' },
         { column = 'admin_level', method = 'btree', where = 'admin_level IS NOT NULL ' },
@@ -57,7 +57,7 @@ tables.place_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'boundary', method = 'btree', where = 'boundary IS NOT NULL ' },
         { column = 'admin_level', method = 'btree', where = 'admin_level IS NOT NULL ' },

--- a/flex-config/style/poi.lua
+++ b/flex-config/style/poi.lua
@@ -141,7 +141,7 @@ tables.poi_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }
@@ -166,7 +166,7 @@ tables.poi_line = osm2pgsql.define_table({
         { column = 'geom', type = 'linestring', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }
@@ -191,7 +191,7 @@ tables.poi_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }

--- a/flex-config/style/public_transport.lua
+++ b/flex-config/style/public_transport.lua
@@ -25,7 +25,7 @@ tables.public_transport_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true }
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }
@@ -57,7 +57,7 @@ tables.public_transport_line = osm2pgsql.define_table({
         { column = 'geom', type = 'multilinestring', projection = srid, not_null = true }
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }
@@ -88,7 +88,7 @@ tables.public_transport_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true }
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }

--- a/flex-config/style/road.lua
+++ b/flex-config/style/road.lua
@@ -19,7 +19,7 @@ tables.road_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true }
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'ref', method = 'btree' },
     }
@@ -49,7 +49,7 @@ tables.road_line = osm2pgsql.define_table({
         { column = 'geom', type = 'multilinestring', projection = srid, not_null = true }
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'major', method = 'btree', where = 'major' },
         { column = 'osm_type', method = 'btree' },
         { column = 'ref', method = 'btree' },
@@ -78,7 +78,7 @@ tables.road_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true }
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'major', method = 'btree', where = 'major' },
         { column = 'osm_type', method = 'btree' },
         { column = 'ref', method = 'btree' },

--- a/flex-config/style/road_major.lua
+++ b/flex-config/style/road_major.lua
@@ -19,7 +19,7 @@ tables.road_major = osm2pgsql.define_table({
         { column = 'geom', type = 'multilinestring', projection = srid, not_null = true },
     },
     indexes = {
-        { column = 'geom', method = 'gist' }
+        { column = 'geom', method = gist_type }
     }
 })
 

--- a/flex-config/style/shop.lua
+++ b/flex-config/style/shop.lua
@@ -25,7 +25,7 @@ tables.shop_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point' , projection = srid, not_null = true },
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }
@@ -55,7 +55,7 @@ tables.shop_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon' , projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL' },
     }

--- a/flex-config/style/traffic.lua
+++ b/flex-config/style/traffic.lua
@@ -13,7 +13,7 @@ tables.traffic_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true },
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }
@@ -30,7 +30,7 @@ tables.traffic_line = osm2pgsql.define_table({
         { column = 'geom', type = 'linestring', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }
@@ -47,7 +47,7 @@ tables.traffic_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }

--- a/flex-config/style/water.lua
+++ b/flex-config/style/water.lua
@@ -17,7 +17,7 @@ tables.water_point = osm2pgsql.define_table({
         { column = 'geom', type = 'point', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }
@@ -40,7 +40,7 @@ tables.water_line = osm2pgsql.define_table({
         { column = 'geom', type = 'multilinestring', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }
@@ -63,7 +63,7 @@ tables.water_polygon = osm2pgsql.define_table({
         { column = 'geom', type = 'multipolygon', projection = srid, not_null = true},
     },
     indexes = {
-        { column = 'geom', method = 'gist' },
+        { column = 'geom', method = gist_type },
         { column = 'osm_type', method = 'btree' },
         { column = 'osm_subtype', method = 'btree', where = 'osm_subtype IS NOT NULL ' },
     }


### PR DESCRIPTION
Follow up to #279, RE https://github.com/openstreetmap/osm2pgsql/issues/1357.  Changes to index creating also allows switching between GIST and SP-GIST indexes. 

## How to use

Add `--sp-gist` to the `docker exec` command.

```bash
docker exec -it \
     pgosm python3 docker/pgosm_flex.py \
    --ram=8 \
    --region=north-america/us \
    --subregion=district-of-columbia \
    --sp-gist
```
