### PR TITLE
Refresh documentation for 0.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,17 +173,18 @@ again in the future, either with the same version of PgOSM Flex or the latest ve
 to load these historic files.
 
 
-If the optional `--pg-dump` option is used, the output `.sql` is also saved in
+If `--pg-dump` option is used the output `.sql` is also saved in
 the `~/pgosm-data` directory.
-This `.sql` file can be loaded into a PostGIS enabled database.
+This `.sql` file can be loaded into any other database with PostGIS and the proper
+permissions.
 
 
 ```bash
 ls -alh ~/pgosm-data/
 
--rw-r--r--  1 root        root         17M Nov  2 19:57 district-of-columbia-2021-11-03.osm.pbf
--rw-r--r--  1 root        root          70 Nov  2 19:59 district-of-columbia-2021-11-03.osm.pbf.md5
--rw-r--r--  1 root        root        156M Nov  3 19:10 pgosm-flex-north-america-us-district-of-columbia-default-2021-11-03.sql
+-rw-r--r-- 1 root     root      18M Jan 21 03:45 district-of-columbia-2023-01-21.osm.pbf
+-rw-r--r-- 1 root     root       70 Jan 21 04:39 district-of-columbia-2023-01-21.osm.pbf.md5
+-rw-r--r-- 1 root     root     163M Jan 21 16:14 north-america-us-district-of-columbia-default-2023-01-21.sql
 ```
 
 

--- a/docs/DOCKER-RUN.md
+++ b/docs/DOCKER-RUN.md
@@ -82,7 +82,16 @@ Prepare the database and permissions as described in
 [POSTGRES-PERMISSIONS.md](POSTGRES-PERMISSIONS.md).
 
 
-Set environment variables to define the connection.
+Set environment variables to define the connection.  Create a file with the
+configuration options.
+
+```bash
+touch ~/.pgosm-db-myproject
+chmod 0700 ~/.pgosm-db-myproject
+nano ~/.pgosm-db-myproject
+```
+
+Put in the contents.
 
 ```bash
 export POSTGRES_USER=your_login_role
@@ -90,6 +99,12 @@ export POSTGRES_PASSWORD=mysecretpassword
 export POSTGRES_HOST=your-host-or-ip
 export POSTGRES_DB=your_db_name
 export POSTGRES_PORT=5432
+```
+
+Env vars can be loaded using.
+
+```bash
+source ~/.pgosm-db-myproject
 ```
 
 ----
@@ -143,7 +158,7 @@ This mode of operation results in larger database as the intermediate osm2pgsql
 tables (`--slim`) must be left in the database (no `--drop`).
 
 
-> Important:  The original `--append` option is now under `--replication`. The `--append` option was removed in PgOSM Flex 0.7.0.  See [the conversation](https://github.com/rustprooflabs/pgosm-flex/issues/275#issuecomment-1340362190) for context.
+> Important:  The original `--append` option is now under `--replication`. The `--append` option was removed in PgOSM Flex 0.7.0.  See [#275](https://github.com/rustprooflabs/pgosm-flex/issues/275) for context.
 
 
 When using replication you need to pin your process to a specific PgOSM Flex version
@@ -459,6 +474,21 @@ time docker exec -it \
     --subregion=colorado \
     --layerset=basic \
     --pgosm-date=2021-10-08
+```
+
+
+## Monitoring the import
+
+You can track the query activity in the database being loaded using the
+`pg_stat_activity` view from `pg_catalog`.  Database connections use
+`application_name = 'pgosm_flex'`.
+
+
+```sql
+SELECT *
+    FROM pg_catalog.pg_stat_activity
+    WHERE application_name = 'pgosm-flex'
+;
 ```
 
 

--- a/docs/POSTGRES-PERMISSIONS.md
+++ b/docs/POSTGRES-PERMISSIONS.md
@@ -1,17 +1,15 @@
 # Postgres permissions for PgOSM Flex
 
-These instructions show an example of setting up a database
-for use with PgOSM Flex.  This should work for both
-[MANUAL-STEPS-RUN.md](MANUAL-STEPS-RUN.md) and
-[DOCKER-RUN.md](DOCKER-RUN.md) instructions.
+These instructions show an example of setting up a Postgres database
+for use with PgOSM Flex as an external database connection
+described in [DOCKER-RUN.md](DOCKER-RUN.md).
 
 ## Create database and PostGIS
 
 These first steps require elevated permissions within Postgres.
-`CREATE DATABASE` requires the `CREATEDB` permission, however
-creating the PostGIS extension requires
+`CREATE DATABASE` requires the `CREATEDB` permission.
+Creating the PostGIS extension requires
 [Postgres superuser permissions](https://blog.rustprooflabs.com/2021/12/postgis-permissions-required).
-
 
 In the target Postgres instance, create your database.
 
@@ -57,7 +55,7 @@ These permissions should allow the full PgOSM Flex process to run.
 
 `GRANT CREATE` gives the `pgosm_flex` role far more permissions than
 it really needs in many cases. 
-Running `docker exec` with `--data-only` skips these steps and would make the `GRANT CREATE` permission unnessecary for the `pgosm_flex` role.
+Running `docker exec` with `--data-only` skips these steps and would make the `GRANT CREATE` permission unnecessary for the `pgosm_flex` role.
 
 It also is often desired to not make
 a login role the owner of database objects. This example reduces the


### PR DESCRIPTION
0.7.0 is bringing a number of breaking changes that result in a lot of docs that needed serious refreshing.

Note:  Some links in this description will break after deleting the associated branch. They're here to make it easier for me to navigate now.

## Main readme

Add quick start to main readme ([current link](https://github.com/rustprooflabs/pgosm-flex/tree/refresh-docs#quick-start)).  That's the piece I always want and can quickly modify for what I'm working on today.  It feels a bit redundant with the Docker Usage section ([current link](https://github.com/rustprooflabs/pgosm-flex/tree/refresh-docs#docker-usage)) but I think that's okay in this case.  (Open to opinions on that!)


## Docker Run Readme [current link](https://github.com/rustprooflabs/pgosm-flex/blob/refresh-docs/docs/DOCKER-RUN.md)

Run section ([current link](https://github.com/rustprooflabs/pgosm-flex/blob/refresh-docs/docs/DOCKER-RUN.md#run-pgosm-flex-container)) now includes back to back sub-sections for internal vs external Postgres connections. 

Replication instructions ([current link](https://github.com/rustprooflabs/pgosm-flex/blob/refresh-docs/docs/DOCKER-RUN.md#use---replication-to-keep-data-fresh)) brought up to be more prominent.  Not recommending as default usage (yet).  Hinting at taking the `experimental` flag off this feature.  It isn't off in the code yet, though I think I'll make that change before releasing 0.7.0 too.

Changing from `--skip-dump` to `--pg-dump`. [current link](https://github.com/rustprooflabs/pgosm-flex/blob/refresh-docs/docs/DOCKER-RUN.md#use---pg-dump-to-export-data)


Improvements about `--skip-nested`. [current link](https://github.com/rustprooflabs/pgosm-flex/blob/refresh-docs/docs/DOCKER-RUN.md#skip-nested-place-polygons)

