### PR TITLE
Add `osm2pgsql_replication` column to `osm.pgosm_flex`

### DIFF
--- a/docker/helpers.py
+++ b/docker/helpers.py
@@ -82,7 +82,7 @@ def verify_checksum(md5_file, path):
 
 
 def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
-                 layerset_path, sp_gist):
+                 layerset_path, sp_gist, replication):
     """Sets environment variables needed by PgOSM Flex.
 
     See /docs/MANUAL-STEPS-RUN.md for usage examples of environment variables.
@@ -99,6 +99,8 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
         str when set, or None
     sp_gist : bool
         When `True` uses SP-GIST index instead of GIST for spatial indexes.
+    replication : bool
+        Indicates when osm2pgsql-replication is used
     """
     logger = logging.getLogger('pgosm-flex')
     logger.debug('Ensuring env vars are not set from prior run')
@@ -141,6 +143,11 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
     else:
         os.environ['PGOSM_GIST_TYPE'] = 'gist'
 
+    if replication:
+        os.environ['PGOSM_REPLICATION'] = 'true'
+    else:
+        os.environ['PGOSM_REPLICATION'] = 'false'
+
 
 def unset_env_vars():
     """Unsets environment variables used by PgOSM Flex.
@@ -158,3 +165,4 @@ def unset_env_vars():
     os.environ.pop('PGOSM_CONN', None)
     os.environ.pop('PGOSM_CONN_PG', None)
     os.environ.pop('PGOSM_GIST_TYPE', None)
+    os.environ.pop('PGOSM_REPLICATION', None)

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -103,7 +103,7 @@ def run_pgosm_flex(ram, region, subregion, data_only, debug,
         region = input_file
 
     helpers.set_env_vars(region, subregion, srid, language, pgosm_date,
-                         layerset, layerset_path, sp_gist)
+                         layerset, layerset_path, sp_gist, replication)
     db.wait_for_postgres()
 
     if replication:

--- a/docs/src/REPLICATION.md
+++ b/docs/src/REPLICATION.md
@@ -47,6 +47,9 @@ in the appropriate `postgresql.conf` file.
 
 
 ```bash
+export POSTGRES_USER=postgres
+export POSTGRES_PASSWORD=mysecretpassword
+
 docker run --name pgosm -d --rm \
     -v ~/pgosm-data:/app/output \
     -v /etc/localtime:/etc/localtime:ro \

--- a/flex-config/sql/pgosm-meta.sql
+++ b/flex-config/sql/pgosm-meta.sql
@@ -11,7 +11,7 @@ COMMENT ON COLUMN osm.pgosm_flex.osm2pgsql_version IS 'Version of osm2pgsql used
 COMMENT ON COLUMN osm.pgosm_flex.region IS 'Region specified at run time via env var PGOSM_REGION.';
 COMMENT ON COLUMN osm.pgosm_flex.language IS 'Preferred language specified at run time via env var PGOSM_LANGUAGE.  Empty string when not defined.';
 COMMENT ON COLUMN osm.pgosm_flex.osm2pgsql_mode IS 'Indicates which osm2pgsql mode was used, create or append.';
-
+COMMENT ON COLUMN osm.pgosm_flex.osm2pgsql_replication IS 'True indicates when osm2pgsql-replication was used for the import.';
 
 
 -- Helper Procedures for allowing updates via osm2pgsql-replication or similar


### PR DESCRIPTION
Closes #295.

Add osm2pgsql_replication column to track when osm2pgsql-replication mode is used in `osm.pgosm_flex` table.

```sql
SELECT id, region, osm_date, pgosm_flex_version,
        osm2pgsql_mode, osm2pgsql_replication
    FROM osm.pgosm_flex 
;
```

```
┌────┬───────────────────────────────────────┬────────────┬────────────────────┬────────────────┬───────────────────────┐
│ id │                region                 │  osm_date  │ pgosm_flex_version │ osm2pgsql_mode │ osm2pgsql_replication │
╞════╪═══════════════════════════════════════╪════════════╪════════════════════╪════════════════╪═══════════════════════╡
│  1 │ north-america/us-district-of-columbia │ 2022-12-30 │ 0.7.0-01ecd52      │ create         │ t                     │
│  2 │ north-america/us-district-of-columbia │ 2023-02-15 │ 0.7.0-01ecd52      │ append         │ t                     │
└────┴───────────────────────────────────────┴────────────┴────────────────────┴────────────────┴───────────────────────┘
```
```