### PR TITLE
Finish removing UUID components

### DIFF
--- a/docker/helpers.py
+++ b/docker/helpers.py
@@ -90,7 +90,7 @@ def verify_checksum(md5_file, path):
 
 
 def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
-                 layerset_path, sp_gist, replication, import_uuid):
+                 layerset_path, sp_gist, replication):
     """Sets environment variables needed by PgOSM Flex. Also creates DB
     record in `osm.pgosm_flex` table.
 
@@ -108,8 +108,6 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
         When `True` uses SP-GIST index instead of GIST for spatial indexes.
     replication : bool
         Indicates when osm2pgsql-replication is used
-    import_uuid : uuid
-        Required to track import failures in Postgres between Python and Lua
     """
     logger = logging.getLogger('pgosm-flex')
     logger.debug('Ensuring env vars are not set from prior run')
@@ -117,7 +115,6 @@ def set_env_vars(region, subregion, srid, language, pgosm_date, layerset,
     logger.debug('Setting environment variables')
 
     os.environ['PGOSM_REGION'] = region
-    os.environ['PGOSM_IMPORT_UUID'] = str(import_uuid)
 
 
     if srid != DEFAULT_SRID:
@@ -215,4 +212,3 @@ def unset_env_vars():
     os.environ.pop('PGOSM_CONN_PG', None)
     os.environ.pop('PGOSM_GIST_TYPE', None)
     os.environ.pop('PGOSM_REPLICATION', None)
-    os.environ.pop('PGOSM_IMPORT_UUID', None)

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import sys
 
 import click
-import uuid
 
 import osm2pgsql_recommendation as rec
 import db
@@ -94,11 +93,8 @@ def run_pgosm_flex(ram, region, subregion, debug,
     if region is None and input_file:
         region = input_file
 
-
-    import_uuid = uuid.uuid4()
     helpers.set_env_vars(region, subregion, srid, language, pgosm_date,
-                         layerset, layerset_path, sp_gist, replication,
-                         import_uuid)
+                         layerset, layerset_path, sp_gist, replication)
     db.wait_for_postgres()
 
     if replication:

--- a/docker/tests/test_geofabrik.py
+++ b/docker/tests/test_geofabrik.py
@@ -1,6 +1,5 @@
 """ Unit tests to cover the Geofabrik module."""
 import unittest
-import uuid
 
 import geofabrik, helpers
 
@@ -9,7 +8,6 @@ SUBREGION_DC = 'district-of-columbia'
 LAYERSET = 'default'
 PGOSM_DATE = '2021-12-02'
 
-IMPORT_UUID = uuid.uuid4()
 
 class GeofabrikTests(unittest.TestCase):
 
@@ -22,8 +20,7 @@ class GeofabrikTests(unittest.TestCase):
                              layerset=LAYERSET,
                              layerset_path=None,
                              sp_gist=False,
-                             replication=False,
-                             import_uuid=IMPORT_UUID)
+                             replication=False)
 
 
     def tearDown(self):
@@ -45,8 +42,7 @@ class GeofabrikTests(unittest.TestCase):
                              layerset=LAYERSET,
                              layerset_path=None,
                              sp_gist=False,
-                             replication=False,
-                             import_uuid=IMPORT_UUID)
+                             replication=False)
 
         result = geofabrik.get_region_filename()
         expected = f'{REGION_US}-latest.osm.pbf'

--- a/docker/tests/test_pgosm_flex.py
+++ b/docker/tests/test_pgosm_flex.py
@@ -1,6 +1,5 @@
 """ Unit tests to cover the DB module."""
 import unittest
-import uuid
 
 import pgosm_flex, helpers
 
@@ -9,7 +8,6 @@ REGION_US = 'north-america/us'
 SUBREGION_DC = 'district-of-columbia'
 LAYERSET = 'default'
 PGOSM_DATE = '2021-12-02'
-IMPORT_UUID = uuid.uuid4()
 
 class PgOSMFlexTests(unittest.TestCase):
 
@@ -22,8 +20,7 @@ class PgOSMFlexTests(unittest.TestCase):
                              layerset=LAYERSET,
                              layerset_path=None,
                              sp_gist=False,
-                             replication=False,
-                             import_uuid=IMPORT_UUID)
+                             replication=False)
 
 
     def tearDown(self):
@@ -95,8 +92,7 @@ class PgOSMFlexTests(unittest.TestCase):
                              layerset=LAYERSET,
                              layerset_path=None,
                              sp_gist=False,
-                             replication=False,
-                             import_uuid=IMPORT_UUID)
+                             replication=False)
 
         input_file = None
         result = pgosm_flex.get_export_filename(input_file)


### PR DESCRIPTION
Follow up to #312.

The UUID was still being set as env vars and being tested.  Hasn't done anything since #312, removing.