### PR TITLE
Add migration script for 0.9.0 changes

### DIFF
--- a/db/data-migration/0.9.0.sql
+++ b/db/data-migration/0.9.0.sql
@@ -1,0 +1,3 @@
+DROP VIEW osm.vbuilding_all;
+DROP VIEW osm.vshop_all;
+DROP MATERIALIZED VIEW osm.vpoi_all;


### PR DESCRIPTION
This migration should be ran post-import with the new version.  The call to refresh the MV will exist until after 0.9.0 completes.