### PR TITLE
Fix nested polygon logic when place=false

### DIFF
--- a/docker/tests/layersets/place_false.ini
+++ b/docker/tests/layersets/place_false.ini
@@ -1,0 +1,2 @@
+[layerset]
+place=false

--- a/docker/tests/layersets/place_missing.ini
+++ b/docker/tests/layersets/place_missing.ini
@@ -1,0 +1,1 @@
+[layerset]

--- a/docker/tests/layersets/place_true.ini
+++ b/docker/tests/layersets/place_true.ini
@@ -1,0 +1,2 @@
+[layerset]
+place=true

--- a/docker/tests/test_pgosm_flex.py
+++ b/docker/tests/test_pgosm_flex.py
@@ -99,3 +99,98 @@ class PgOSMFlexTests(unittest.TestCase):
         expected = 'north-america-default-2021-12-02.sql'
         self.assertEqual(expected, result)
 
+    def test_layerset_include_place_returns_boolean(self):
+        helpers.unset_env_vars()
+        layerset_path = None
+        helpers.set_env_vars(region='north-america',
+                             subregion=None,
+                             srid=3857,
+                             language=None,
+                             pgosm_date=PGOSM_DATE,
+                             layerset=LAYERSET,
+                             layerset_path=layerset_path,
+                             sp_gist=False,
+                             replication=False)
+
+        paths = pgosm_flex.get_paths()
+        result = pgosm_flex.layerset_include_place(flex_path=paths['flex_path'])
+        expected = bool
+        actual = type(result)
+        self.assertEqual(expected, actual)
+
+    def test_layerset_include_place_returns_True_with_default_layerset(self):
+        helpers.unset_env_vars()
+        layerset_path = None
+        helpers.set_env_vars(region='north-america',
+                             subregion=None,
+                             srid=3857,
+                             language=None,
+                             pgosm_date=PGOSM_DATE,
+                             layerset=LAYERSET,
+                             layerset_path=layerset_path,
+                             sp_gist=False,
+                             replication=False)
+
+        paths = pgosm_flex.get_paths()
+        actual = pgosm_flex.layerset_include_place(flex_path=paths['flex_path'])
+        expected = True
+        self.assertEqual(expected, actual)
+
+    def test_layerset_include_place_returns_false_when_place_false_in_ini(self):
+        helpers.unset_env_vars()
+        layerset_path = '/app/docker/tests/layersets'
+        layerset = 'place_false'
+        helpers.set_env_vars(region='north-america',
+                             subregion=None,
+                             srid=3857,
+                             language=None,
+                             pgosm_date=PGOSM_DATE,
+                             layerset=layerset,
+                             layerset_path=layerset_path,
+                             sp_gist=False,
+                             replication=False)
+
+        paths = pgosm_flex.get_paths()
+        actual = pgosm_flex.layerset_include_place(flex_path=paths['flex_path'])
+        expected = False
+        self.assertEqual(expected, actual)
+
+    def test_layerset_include_place_returns_false_when_place_missing_in_ini(self):
+        helpers.unset_env_vars()
+        layerset_path = '/app/docker/tests/layersets'
+        layerset = 'place_missing'
+        helpers.set_env_vars(region='north-america',
+                             subregion=None,
+                             srid=3857,
+                             language=None,
+                             pgosm_date=PGOSM_DATE,
+                             layerset=layerset,
+                             layerset_path=layerset_path,
+                             sp_gist=False,
+                             replication=False)
+
+        paths = pgosm_flex.get_paths()
+        actual = pgosm_flex.layerset_include_place(flex_path=paths['flex_path'])
+        expected = False
+        self.assertEqual(expected, actual)
+
+    def test_layerset_include_place_returns_true_when_place_true_in_ini(self):
+        helpers.unset_env_vars()
+        layerset_path = '/app/docker/tests/layersets'
+        layerset = 'place_true'
+        helpers.set_env_vars(region='north-america',
+                             subregion=None,
+                             srid=3857,
+                             language=None,
+                             pgosm_date=PGOSM_DATE,
+                             layerset=layerset,
+                             layerset_path=layerset_path,
+                             sp_gist=False,
+                             replication=False)
+
+        paths = pgosm_flex.get_paths()
+        actual = pgosm_flex.layerset_include_place(flex_path=paths['flex_path'])
+        expected = True
+        self.assertEqual(expected, actual)
+
+


### PR DESCRIPTION
Addresses #347.

Fix logic related to skipping nested place polygon function when `place=false` in the layerset INI.  The problem was the value from the ini file was being returned as a `str`, while the logic was expecting a `bool`.  This moves the value parsing logic into a new function explicitly to return the boolean value, and adds unit tests to verify functionality.

With this change, it establishes that the case insensitive `true` is interpreted as `True`, everything else is `False`.

This commit is currently available as the `dev` image.

```bash
docker pull rustprooflabs/pgosm-flex:dev
```