### PR TITLE
Fix mdbook deploy error - set fixed versions

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -18,7 +18,8 @@ jobs:
         echo "PATH=$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
     - name: Install mdbook
       run: |
-        cargo install mdbook mdbook-variables
+        cargo install mdbook --version 0.4.32
+        cargo install mdbook-variables --version 0.2.2
     - name: Deploy GitHub Pages
       run: |
         # This assumes your book is in the root of your repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@ The book is built [using `mdbook`](https://rust-lang.github.io/mdBook/index.html
 Install mdbook.
 
 ```bash
-cargo install mdbook
-cargo install mdbook-variables
+cargo install mdbook --version 0.4.32
+cargo install mdbook-variables --version 0.2.2
 ```
 
 Serve the book locally and open your default browser.

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -14,4 +14,4 @@ git-repository-icon = "fa-github"
 edit-url-template = "https://github.com/rustprooflabs/pgosm-flex/edit/main/docs/{path}"
 
 [preprocessor.variables.variables]
-pgosm_flex_version = "0.8.0"
+pgosm_flex_version = "0.10.0"


### PR DESCRIPTION
Set mdbook and mdbook-variables to install fixed versions to avoid deploy error.

https://github.com/rustprooflabs/pgosm-flex/actions/runs/5693129167

Saw reference to [this change in PL/Rust](https://github.com/tcdi/plrust/pull/360), pinned versions to match what I have installed locally. 

