### PR TITLE
Track `--input-file` when used

### DIFF
--- a/db/deploy/osm_pgosm_flex.sql
+++ b/db/deploy/osm_pgosm_flex.sql
@@ -14,6 +14,7 @@ CREATE TABLE IF NOT EXISTS {schema_name}.pgosm_flex (
     "language" text NOT NULL,
     import_mode JSONB NULL,
     import_status TEXT NOT NULL DEFAULT 'Initializing',
+    input_file TEXT NULL,
     CONSTRAINT pk_osm_pgosm_flex PRIMARY KEY (id)
 );
 
@@ -36,6 +37,9 @@ ALTER TABLE {schema_name}.pgosm_flex
 ALTER TABLE {schema_name}.pgosm_flex
     ADD COLUMN IF NOT EXISTS layerset TEXT NULL;
 
+ALTER TABLE {schema_name}.pgosm_flex
+    ADD COLUMN IF NOT EXISTS input_file TEXT NULL;
+
 ALTER TABLE {schema_name}.pgosm_flex DROP COLUMN IF EXISTS project_url;
 ALTER TABLE {schema_name}.pgosm_flex DROP COLUMN IF EXISTS default_date;
 
@@ -46,10 +50,12 @@ COMMENT ON COLUMN {schema_name}.pgosm_flex.osm_date IS 'Indicates the date of th
 COMMENT ON COLUMN {schema_name}.pgosm_flex.srid IS 'SRID of imported data.';
 COMMENT ON COLUMN {schema_name}.pgosm_flex.pgosm_flex_version IS 'Version of PgOSM-Flex used to generate schema.';
 COMMENT ON COLUMN {schema_name}.pgosm_flex.osm2pgsql_version IS 'Version of osm2pgsql used to load data.';
-COMMENT ON COLUMN {schema_name}.pgosm_flex.region IS 'Region specified at run time via env var PGOSM_REGION.';
+COMMENT ON COLUMN {schema_name}.pgosm_flex.region IS 'Region specified at run time via --region and --subregion values.  When using --input-file without region/subregion, this defaults to the input filename.';
 COMMENT ON COLUMN {schema_name}.pgosm_flex.language IS 'Preferred language specified at run time via env var PGOSM_LANGUAGE.  Empty string when not defined.';
 COMMENT ON COLUMN {schema_name}.pgosm_flex.layerset IS 'PgOSM Flex layerset used for the import style.';
 COMMENT ON COLUMN {schema_name}.pgosm_flex.import_status IS 'Status of the import. Starts as initialized, tracks status during imports and final success/failure.';
+COMMENT ON COLUMN {schema_name}.pgosm_flex.input_file IS 'Tracks explicit file defined when --input-file is used.  NULL when --input-file not used.';
+
 
 
 COMMIT;

--- a/docker/db.py
+++ b/docker/db.py
@@ -237,7 +237,7 @@ def prepare_pgosm_db(skip_qgis_style, db_path, import_mode, schema_name):
 
 
 def start_import(pgosm_region, pgosm_date, srid, language, layerset, git_info,
-                 osm2pgsql_version, import_mode, schema_name):
+                 osm2pgsql_version, import_mode, schema_name, input_file):
     """Creates record in osm.pgosm_flex table.
 
     Parameters
@@ -251,6 +251,7 @@ def start_import(pgosm_region, pgosm_date, srid, language, layerset, git_info,
     osm2pgsql_version : str
     import_mode : import_mode.ImportMode
     schema_name : str
+    input_file : str
 
     Returns
     ----------------------------
@@ -260,16 +261,18 @@ def start_import(pgosm_region, pgosm_date, srid, language, layerset, git_info,
     params = {'pgosm_region': pgosm_region, 'pgosm_date': pgosm_date,
               'srid': srid, 'language': language, 'layerset': layerset,
               'git_info': git_info, 'osm2pgsql_version': osm2pgsql_version,
-              'import_mode': import_mode.as_json()}
+              'import_mode': import_mode.as_json(),
+              'input_file': input_file}
 
     sql_raw = """
 INSERT INTO {schema_name}.pgosm_flex
     (osm_date, region, pgosm_flex_version, srid,
         osm2pgsql_version, "language", import_mode,
-        layerset)
+        layerset, input_file)
     VALUES(%(pgosm_date)s, %(pgosm_region)s, %(git_info)s, %(srid)s,
         %(osm2pgsql_version)s,
-        COALESCE(%(language)s, ''), %(import_mode)s, %(layerset)s
+        COALESCE(%(language)s, ''), %(import_mode)s, %(layerset)s,
+        %(input_file)s
         )
     RETURNING id
 ;

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -151,7 +151,8 @@ def run_pgosm_flex(ram, region, subregion, debug, force,
                                 git_info=helpers.get_git_info(),
                                 osm2pgsql_version=vers_lines,
                                 import_mode=import_mode,
-                                schema_name=schema_name)
+                                schema_name=schema_name,
+                                input_file=input_file)
 
     logger.info(f'Started import id {import_id}')
 


### PR DESCRIPTION
Add `input_file` column to `pgosm_flex` table to track detail when used.  Improves comment on `region` column.