### PR TITLE
Draft: (Don't Merge)  Install H3 extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN wget https://github.com/rustprooflabs/pgdd/releases/download/0.5.1/pgdd_0.5.
     && rm ./convert_0.0.3_postgis_pg16_amd64.deb
 
 RUN pip install pgxnclient \
-    && pgxn install h3=4.1.2
+    && pgxn install h3
 
 WORKDIR /app
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     #&& apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         sqitch wget ca-certificates \
-        git make cmake g++ \
+        git make g++ \
         libboost-dev libboost-system-dev \
         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
         libbz2-dev libpq-dev libproj-dev lua5.4 liblua5.4-dev \
@@ -18,7 +18,13 @@ RUN apt-get update \
         curl unzip \
         postgresql-16-pgrouting \
         nlohmann-json3-dev \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    ## Manually installing latest CMake to enable installing
+    ## h3 extension via pgxn. Otherwise cmake is too old on Debian 11
+    && wget https://cmake.org/files/v3.27/cmake-3.27.0.tar.gz \
+    && tar -xf cmake-3.27.0.tar.gz \
+    && cd cmake-3.27.0 \
+    && ./configure && make && make install
 
 RUN wget https://luarocks.org/releases/luarocks-3.9.2.tar.gz \
     && tar zxpf luarocks-3.9.2.tar.gz \
@@ -40,12 +46,6 @@ RUN git clone --depth 1 --branch $OSM2PGSQL_BRANCH https://github.com/openstreet
     && cmake .. -D USE_PROJ_LIB=6 \
     && make -j$(nproc) \
     && make install \
-    && apt remove -y \
-        make cmake g++ \
-        libexpat1-dev zlib1g-dev \
-        libbz2-dev libproj-dev \
-        curl \
-    && apt autoremove -y \
     && cd /tmp && rm -r /tmp/osm2pgsql
 
 RUN wget https://github.com/rustprooflabs/pgdd/releases/download/0.5.1/pgdd_0.5.1_postgis_pg16_amd64.deb \
@@ -55,9 +55,17 @@ RUN wget https://github.com/rustprooflabs/pgdd/releases/download/0.5.1/pgdd_0.5.
     && dpkg -i ./convert_0.0.3_postgis_pg16_amd64.deb \
     && rm ./convert_0.0.3_postgis_pg16_amd64.deb
 
-
+RUN pip install pgxnclient \
+    && pgxn install h3=4.1.2
 
 WORKDIR /app
 COPY . ./
 
 RUN pip install --upgrade pip && pip install -r requirements.txt
+
+RUN apt remove -y \
+        make g++ \
+        libexpat1-dev zlib1g-dev \
+        libbz2-dev libproj-dev \
+        curl \
+    && apt autoremove -y


### PR DESCRIPTION
# Details

This adds the [h3 extension](https://github.com/zachasme/h3-pg) into the Docker image.  As it stands, I do not plan to merge this into `main`.  To install h3 via pgxn I needed a version of `cmake` newer than what is on Debian 11.  Building a newer cmake from source is a huge slowdown to initial `docker build`.

I haven't tried going down the path of building the h3 extension from source.  I suspect I will encounter the same minimum cmake version.


```
real	19m7.325s
user	0m2.124s
sys	0m1.271s
```

