### PR TITLE
Testing osm2pgsql PR #2134 for reducing conections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM postgis/postgis:16-3.4
 
 LABEL maintainer="PgOSM Flex - https://github.com/rustprooflabs/pgosm-flex"
 
-ARG OSM2PGSQL_BRANCH=master
+#ARG OSM2PGSQL_BRANCH=master
+ARG OSM2PGSQL_BRANCH=fewer-db-conns
+# ARG  OSM2PGSQL_REPO=https://github.com/openstreetmap/osm2pgsql.git
+ARG OSM2PGSQL_REPO=https://github.com/joto/osm2pgsql.git
+
 
 RUN apt-get update \
     # Removed upgrade per https://github.com/rustprooflabs/pgosm-flex/issues/322
@@ -34,7 +38,7 @@ RUN luarocks install luasql-postgres PGSQL_INCDIR=/usr/include/postgresql/
 
 
 WORKDIR /tmp
-RUN git clone --depth 1 --branch $OSM2PGSQL_BRANCH https://github.com/openstreetmap/osm2pgsql.git \
+RUN git clone --depth 1 --branch $OSM2PGSQL_BRANCH $OSM2PGSQL_REPO \
     && mkdir osm2pgsql/build \
     && cd osm2pgsql/build \
     && cmake .. -D USE_PROJ_LIB=6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM postgis/postgis:16-3.4
 
 LABEL maintainer="PgOSM Flex - https://github.com/rustprooflabs/pgosm-flex"
 
-#ARG OSM2PGSQL_BRANCH=master
-ARG OSM2PGSQL_BRANCH=fewer-db-conns
-# ARG  OSM2PGSQL_REPO=https://github.com/openstreetmap/osm2pgsql.git
-ARG OSM2PGSQL_REPO=https://github.com/joto/osm2pgsql.git
+ARG OSM2PGSQL_BRANCH=master
+ARG OSM2PGSQL_REPO=https://github.com/openstreetmap/osm2pgsql.git
 
 
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM postgis/postgis:16-3.4
 LABEL maintainer="PgOSM Flex - https://github.com/rustprooflabs/pgosm-flex"
 
 ARG OSM2PGSQL_BRANCH=master
-ARG OSM2PGSQL_REPO=https://github.com/openstreetmap/osm2pgsql.git
+ARG OSM2PGSQL_REPO=https://github.com/osm2pgsql-dev/osm2pgsql.git
 
 
 RUN apt-get update \

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -268,9 +268,9 @@ def run_replication_update(skip_nested, flex_path):
 osm2pgsql-replication update -d $PGOSM_CONN \
     -- \
     --output=flex --style=./run.lua \
-    --slim \
-    -d $PGOSM_CONN
-"""
+    --slim
+    """
+
     update_cmd = update_cmd.replace('-d $PGOSM_CONN', f'-d {conn_string}')
     returncode = helpers.run_command_via_subprocess(cmd=update_cmd.split(),
                                                     cwd=flex_path,
@@ -422,7 +422,7 @@ def run_osm2pgsql(osm2pgsql_command, flex_path, debug):
     """
     logger = logging.getLogger('pgosm-flex')
     logger.info('Running osm2pgsql')
-        
+
     returncode = helpers.run_command_via_subprocess(cmd=osm2pgsql_command.split(),
                                                     cwd=flex_path,
                                                     print=True)


### PR DESCRIPTION
This PR started by testing https://github.com/osm2pgsql-dev/osm2pgsql/pull/2134.  Those results were encouraging and is now this is a PR addressing a couple other minor improvements.  

* Uses latest osm2pgsql, significantly reducing connection volume to Postgres https://github.com/osm2pgsql-dev/osm2pgsql/pull/2134
* Remove extra `-d` from `osm2pgsql-replication` - required to work with https://github.com/osm2pgsql-dev/osm2pgsql/pull/2115 
* Add `OSM2PGSQL_REPO` to Dockerfile for easier testing
* Adjust GitHub URL for change to `/osm2pgsql-dev/` (from `/openstreetmap/`