### PR TITLE
Fixes 383: Pass parameters to psycopg instead of a connection string

### DIFF
--- a/docker/db.py
+++ b/docker/db.py
@@ -54,10 +54,18 @@ def connection_string(admin: bool=False) -> str:
     else:
         db_name = pg_db
 
-    if pg_pass is None:
-        conn_string = f'postgresql://{pg_user}@{pg_host}:{pg_port}/{db_name}{app_str}'
-    else:
-        conn_string = f'postgresql://{pg_user}:{pg_pass}@{pg_host}:{pg_port}/{db_name}{app_str}'
+    conn_kwargs = {
+        'dbname': db_name,
+        'user': pg_user,
+        'host': pg_host,
+        'port': pg_port,
+        'application_name': 'pgosm-flex'
+    }
+
+    if pg_pass is not None:
+        conn_kwargs['password'] = pg_pass
+
+    conn_string = psycopg.conninfo(**conn_kwargs)
 
     return conn_string
 

--- a/docker/db.py
+++ b/docker/db.py
@@ -65,7 +65,7 @@ def connection_string(admin: bool=False) -> str:
     if pg_pass is not None:
         conn_kwargs['password'] = pg_pass
 
-    conn_string = psycopg.conninfo(**conn_kwargs)
+    conn_string = psycopg.conninfo.make_conninfo(**conn_kwargs)
 
     return conn_string
 

--- a/docker/tests/test_db.py
+++ b/docker/tests/test_db.py
@@ -6,7 +6,7 @@ from unittest import mock
 import db
 
 POSTGRES_USER = 'my_pg_user'
-POSTGRES_PASSWORD = 'here_for_fun'
+POSTGRES_PASSWORD = 'here_for_fun!@#$%^&*()'
 POSTGRES_HOST_EXTERNAL = 'not-intented-to-be-real'
 
 PG_USER_ONLY = {'POSTGRES_USER': POSTGRES_USER,
@@ -42,14 +42,14 @@ class DBTests(unittest.TestCase):
 
     @mock.patch.dict(os.environ, PG_USER_ONLY)
     def test_connection_string_user_only_returns_expected_string(self):
-        expected = f'postgresql://{POSTGRES_USER}@localhost:5432/pgosm?application_name=pgosm-flex'
+        expected = f"dbname='pgosm' user='{POSTGRES_USER}' host='localhost' port='5432' application_name='pgosm-flex'"
         result = db.connection_string()
         self.assertEqual(expected, result)
 
 
     @mock.patch.dict(os.environ, PG_USER_AND_PW)
     def test_connection_string_user_w_pw_returns_expected_string(self):
-        expected = f'postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@localhost:5432/pgosm?application_name=pgosm-flex'
+        expected = f"dbname='pgosm' user='{POSTGRES_USER}' password='{POSTGRES_PASSWORD}' host='localhost' port='5432' application_name='pgosm-flex'"
         result = db.connection_string()
         self.assertEqual(expected, result)
 
@@ -60,7 +60,7 @@ class DBTests(unittest.TestCase):
         standard & admin connections. Only use of admin connection w/ external
         Postgres is version check.
         """
-        expected = f'postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST_EXTERNAL}:5432/pgosm?application_name=pgosm-flex'
+        expected = f"dbname='pgosm' user='{POSTGRES_USER}' password='{POSTGRES_PASSWORD}' host='{POSTGRES_HOST_EXTERNAL}' port='5432' application_name='pgosm-flex'"
         result_standard = db.connection_string()
         result_admin = db.connection_string(admin=True)
         self.assertEqual(expected, result_standard)
@@ -98,4 +98,3 @@ class DBTests(unittest.TestCase):
         actual = type(result)
         expected = dict
         self.assertEqual(expected, actual)
-


### PR DESCRIPTION
This should fix #383.

I didn't have time to get all of the tests passing, but, it's looking like 95%.