### PR TITLE
Allow special characters in DB connection parts

### DIFF
--- a/docker/db.py
+++ b/docker/db.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 import psycopg
 import sh
+from urllib import parse
 
 import qgis_styles
 
@@ -37,11 +38,14 @@ def connection_string(admin: bool=False) -> str:
     app_str = '?application_name=pgosm-flex'
 
     pg_details = pg_conn_parts()
-    pg_user = pg_details['pg_user']
-    pg_pass = pg_details['pg_pass']
-    pg_host = pg_details['pg_host']
-    pg_db = pg_details['pg_db']
-    pg_port = pg_details['pg_port']
+    pg_user = parse.quote(pg_details['pg_user'])
+    try:
+        pg_pass = parse.quote(pg_details['pg_pass'])
+    except TypeError:
+        pg_pass = None
+    pg_host = parse.quote(pg_details['pg_host'])
+    pg_db = parse.quote(pg_details['pg_db'])
+    pg_port = parse.quote(pg_details['pg_port'])
 
     if admin:
         if pg_host == 'localhost':

--- a/docker/tests/test_db.py
+++ b/docker/tests/test_db.py
@@ -1,12 +1,13 @@
 """ Unit tests to cover the DB module."""
 import os
 import unittest
+from urllib import parse
 from unittest import mock
 
 import db
 
 POSTGRES_USER = 'my_pg_user'
-POSTGRES_PASSWORD = 'here_for_fun'
+POSTGRES_PASSWORD = 'here_for_fun!@#$%^&*()'
 POSTGRES_HOST_EXTERNAL = 'not-intented-to-be-real'
 
 PG_USER_ONLY = {'POSTGRES_USER': POSTGRES_USER,
@@ -49,7 +50,8 @@ class DBTests(unittest.TestCase):
 
     @mock.patch.dict(os.environ, PG_USER_AND_PW)
     def test_connection_string_user_w_pw_returns_expected_string(self):
-        expected = f'postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@localhost:5432/pgosm?application_name=pgosm-flex'
+        password_safe = parse.quote(POSTGRES_PASSWORD)
+        expected = f'postgresql://{POSTGRES_USER}:{password_safe}@localhost:5432/pgosm?application_name=pgosm-flex'
         result = db.connection_string()
         self.assertEqual(expected, result)
 
@@ -60,7 +62,8 @@ class DBTests(unittest.TestCase):
         standard & admin connections. Only use of admin connection w/ external
         Postgres is version check.
         """
-        expected = f'postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST_EXTERNAL}:5432/pgosm?application_name=pgosm-flex'
+        password_safe = parse.quote(POSTGRES_PASSWORD)
+        expected = f'postgresql://{POSTGRES_USER}:{password_safe}@{POSTGRES_HOST_EXTERNAL}:5432/pgosm?application_name=pgosm-flex'
         result_standard = db.connection_string()
         result_admin = db.connection_string(admin=True)
         self.assertEqual(expected, result_standard)


### PR DESCRIPTION
# Details

Addresses #383, tests based on #384.

This approach uses `urllib.prase.quote()` to handle special characters in Postgres passwords and other conn string components.  This allows continuing to use URI style connection strings. There are a variety of places throughout the code that expect URI style connections.

The `quote()` method appears to handle the requirements defined by Postgres.

> "The connection URI needs to be encoded with [percent-encoding](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) if it includes symbols with special meaning in any of its parts. Here is an example where the equal sign (=) is replaced with %3D and the space character with %20:"
>    From  [Postgres libpq connection docs](https://www.postgresql.org/docs/current/libpq-connect.html)

Thank you @jmealo for all the sleuthing you did to determine the cause of the issue and suggesting a path forward!  I'll get an updated `:latest` image pushed soon, will comment here when that's ready.