### PR TITLE
Fix uncaught error when data too old for replication update

### DIFF
--- a/docker/geofabrik.py
+++ b/docker/geofabrik.py
@@ -88,7 +88,7 @@ def set_date_from_metadata(pbf_file: str):
     returncode = helpers.run_command_via_subprocess(cmd=osmium_cmd.split(),
                                                     cwd=None,
                                                     output_lines=output,
-                                                    print=False)
+                                                    print_to_log=False)
     if returncode != 0:
         logger.error(f'osmium fileinfo failed.  Output: {output}')
 

--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -273,7 +273,7 @@ osm2pgsql-replication update -d $PGOSM_CONN \
     update_cmd = update_cmd.replace('-d $PGOSM_CONN', f'-d {conn_string}')
     returncode = helpers.run_command_via_subprocess(cmd=update_cmd.split(),
                                                     cwd=flex_path,
-                                                    print=True)
+                                                    print_to_log=True)
 
     if returncode != 0:
         err_msg = f'Failure. Return code: {returncode}'
@@ -424,7 +424,7 @@ def run_osm2pgsql(osm2pgsql_command, flex_path, debug):
 
     returncode = helpers.run_command_via_subprocess(cmd=osm2pgsql_command.split(),
                                                     cwd=flex_path,
-                                                    print=True)
+                                                    print_to_log=True)
 
     if returncode != 0:
         err_msg = f'Failed to run osm2pgsql. Return code: {returncode}'
@@ -586,7 +586,7 @@ def check_replication_exists():
     return True
 
 
-def run_osm2pgsql_replication_init(pbf_path, pbf_filename):
+def run_osm2pgsql_replication_init(pbf_path: str, pbf_filename: str):
     """Runs osm2pgsql-replication init to support replication mode.
 
     Parameters
@@ -604,7 +604,7 @@ def run_osm2pgsql_replication_init(pbf_path, pbf_filename):
 
     returncode = helpers.run_command_via_subprocess(cmd=init_cmd.split(),
                                                     cwd=None,
-                                                    print=True)
+                                                    print_to_log=True)
 
     if returncode != 0:
         err_msg = f'Failed to run osm2pgsql-replication. Return code: {returncode}'


### PR DESCRIPTION
Closes #391.

### Error in main output

```
2024-07-06 08:22:26,658:INFO:pgosm-flex:helpers:2024-07-06 08:22:26 [INFO]: Using replication service 'http://download.geofabrik.de/north-america/us/district-of-columbia-updates'.
2024-07-06 08:22:27,940:INFO:pgosm-flex:helpers:2024-07-06 08:22:27 [ERROR]: Error during diff download. Bailing out.
2024-07-06 08:22:27,940:ERROR:pgosm-flex:helpers:Data in database is too far behind replication service.
2024-07-06 08:22:27,965:WARNING:pgosm-flex:pgosm_flex:Failure. Return code: 999
2024-07-06 08:22:27,994:WARNING:pgosm-flex:pgosm_flex:PgOSM Flex completed with errors. Details in output
PgOSM Flex completed with errors. Details in output

```

### Reports as failure in DB

```
imported                     |osm_date  |pgosm_flex_version|import_status|
-----------------------------+----------+------------------+-------------+
2024-07-06 07:43:33.196 -0600|2024-07-06|1.0.1-e53f4cf     |Failed       |
2024-07-06 07:41:27.535 -0600|2024-07-06|1.0.1-e53f4cf     |Completed    |
```