### PR TITLE
Handle Replication/Force combination

### DIFF
--- a/docker/pgosm_flex.py
+++ b/docker/pgosm_flex.py
@@ -105,6 +105,12 @@ def run_pgosm_flex(ram, region, subregion, debug, force,
 
     if replication:
         replication_update = check_replication_exists()
+        if replication_update and force:
+            err_msg = 'Using --force is invalid when --replication is running an update.'
+            err_msg += ' See https://pgosm-flex.com/replication.html#resetting-replication'
+            err_msg += ' for instructions around this on a development server.'
+            logger.error(err_msg)
+            sys.exit(f'ERROR: {err_msg}')
     else:
         replication_update = False
 

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -86,3 +86,26 @@ using `--schema-name`, replication via osm2pgsql-replication only supports
 a single source.  See [this issue](https://github.com/openstreetmap/osm2pgsql/pull/1769)
 for details.  Possibly this ability will be supported in the future.
 
+
+## Resetting Replication
+
+> ⚠️ WARNING! ⚠️ This section is <strong>only suitable for DEVELOPMENT databases</strong>.
+> Do NOT USE on production databases!
+
+Replication with PgOSM Flex `--replication` is simply a wrapper around the
+`osm2pgsql-replication` tool. If you need to reload a <strong>development</strong>
+database after using `--replication` you must remove the data from the
+`public.osm2pgsql_properties` table.  If you do not remove this data,
+PgOSM Flex will detect the replication setup and attempt to update data, not
+load fresh.
+
+
+```sql
+DELETE FROM public.osm2pgsql_properties;
+```
+
+> WARNING: This process works as an okay hack when you are using the same layerset
+> in the new import as was previously used.  If you use a layerset with fewer
+> tables, the original tables from the original layerset will persist and can
+> cause confusion about what was loaded.
+


### PR DESCRIPTION
Prevent using `--replication` and `--force` when existing replication data exists. Add docs on how to work around for `dev` purposes.  Trying to use this on a old, messy dev server made things confusing for me a bit so failing the run and providing link to new documentation on what to do.