### PR TITLE
Adjust for changes to osm2pgsql RE replication initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM postgis/postgis:16-3.4
 
 LABEL maintainer="PgOSM Flex - https://github.com/rustprooflabs/pgosm-flex"
 
-ARG OSM2PGSQL_BRANCH=master
-ARG OSM2PGSQL_REPO=https://github.com/osm2pgsql-dev/osm2pgsql.git
+#ARG OSM2PGSQL_BRANCH=master
+ARG OSM2PGSQL_BRANCH=check-date-on-replication-init
+#ARG OSM2PGSQL_REPO=https://github.com/osm2pgsql-dev/osm2pgsql.git
+ARG OSM2PGSQL_REPO=https://github.com/lonvia/osm2pgsql.git
 
 
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM postgis/postgis:16-3.4
 
 LABEL maintainer="PgOSM Flex - https://github.com/rustprooflabs/pgosm-flex"
 
-#ARG OSM2PGSQL_BRANCH=master
-ARG OSM2PGSQL_BRANCH=check-date-on-replication-init
-#ARG OSM2PGSQL_REPO=https://github.com/osm2pgsql-dev/osm2pgsql.git
-ARG OSM2PGSQL_REPO=https://github.com/lonvia/osm2pgsql.git
+ARG OSM2PGSQL_BRANCH=master
+ARG OSM2PGSQL_REPO=https://github.com/osm2pgsql-dev/osm2pgsql.git
 
 
 RUN apt-get update \

--- a/docs/src/docker-build.md
+++ b/docs/src/docker-build.md
@@ -89,3 +89,29 @@ docker pull postgis/postgis:16-3.4
 docker build --no-cache -t rustprooflabs/pgosm-flex:dev .
 ```
 
+
+## Building PgOSM Flex from an `osm2pgsql` feature branch
+
+There are times it is helpful to build the PgOSM Flex Docker image with a
+specific feature branch. To do this, change the `OSM2PGSQL_BRANCH` 
+and/or `OSM2PGSQL_REPO` arguments as necessary at the beginning of the Dockerfile.
+The production setup looks like the following example.
+
+
+```Dockerfile
+ARG OSM2PGSQL_BRANCH=master
+ARG OSM2PGSQL_REPO=https://github.com/osm2pgsql-dev/osm2pgsql.git
+```
+
+To test the feature branch associated with
+[osm2pgsql #2212](https://github.com/osm2pgsql-dev/osm2pgsql/pull/2212)
+the updated version was set like the following example.
+This changes the `OSM2PGSQL_BRANCH` to `check-date-on-replication-init`
+and changes the username in the `OSM2PGSQL_REPO` to `lonvia`.
+
+
+```Dockerfile
+ARG OSM2PGSQL_BRANCH=check-date-on-replication-init
+ARG OSM2PGSQL_REPO=https://github.com/lonvia/osm2pgsql.git
+```
+

--- a/docs/src/replication.md
+++ b/docs/src/replication.md
@@ -34,6 +34,12 @@ your specific database and process.**
 
 ----
 
+## Not tested by `make`
+
+The function exposed by `--replication` is not tested via PgOSM's `Makefile`.
+
+
+
 ## Max connections
 
 The other important change when using replication is to increase Postgres' `max_connections`.


### PR DESCRIPTION
Following https://github.com/osm2pgsql-dev/osm2pgsql/pull/2212, RE #392.

Add related documentation for how to do this testing, and that replication is not being tested by the makefile. 

Removes test broken by `osm2pgsql` #2212. The removed test only validated the initial setup of replication, not more complicated bits. `osm2pgsql` now raises an error when the file is too old (because it can't possibly update from it), which is a good thing.

If someone in the future wants to suggest an effective approach to testing the replication functionality, feel free submit an issue or PR!


