### PR TITLE
Upgrade from Postgres 16 to Postgres 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:16-3.4
+FROM postgis/postgis:17-3.5
 
 LABEL maintainer="PgOSM Flex - https://github.com/rustprooflabs/pgosm-flex"
 
@@ -16,9 +16,9 @@ RUN apt-get update \
         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
         libbz2-dev libpq-dev libproj-dev lua5.4 liblua5.4-dev \
         python3 python3-distutils \
-        postgresql-server-dev-16 \
+        postgresql-server-dev-17 \
         curl unzip \
-        postgresql-16-pgrouting \
+        postgresql-17-pgrouting \
         nlohmann-json3-dev \
         osmium-tool \
     && rm -rf /var/lib/apt/lists/*
@@ -51,12 +51,12 @@ RUN git clone --depth 1 --branch $OSM2PGSQL_BRANCH $OSM2PGSQL_REPO \
     && apt autoremove -y \
     && cd /tmp && rm -r /tmp/osm2pgsql
 
-RUN wget https://github.com/rustprooflabs/pgdd/releases/download/0.5.1/pgdd_0.5.1_postgis_pg16_amd64.deb \
-    && dpkg -i ./pgdd_0.5.1_postgis_pg16_amd64.deb \
-    && rm ./pgdd_0.5.1_postgis_pg16_amd64.deb \
-    && wget https://github.com/rustprooflabs/convert/releases/download/0.0.3/convert_0.0.3_postgis_pg16_amd64.deb \
-    && dpkg -i ./convert_0.0.3_postgis_pg16_amd64.deb \
-    && rm ./convert_0.0.3_postgis_pg16_amd64.deb
+RUN wget https://github.com/rustprooflabs/pgdd/releases/download/0.6.0/pgdd_0.6.0_postgis_pg17_amd64.deb \
+    && dpkg -i ./pgdd_0.6.0_postgis_pg17_amd64.deb \
+    && rm ./pgdd_0.6.0_postgis_pg17_amd64.deb \
+    && wget https://github.com/rustprooflabs/convert/releases/download/0.0.4/convert_0.0.4_postgis_pg17_amd64.deb \
+    && dpkg -i ./convert_0.0.4_postgis_pg17_amd64.deb \
+    && rm ./convert_0.0.4_postgis_pg17_amd64.deb
 
 
 


### PR DESCRIPTION
# Details

I was able to upgrade the extensions packaged in this Docker image to support Postgres 17 (see [PgDD 0.6.0](https://github.com/rustprooflabs/pgdd/releases/tag/0.6.0) and [Convert 0.0.4](https://github.com/rustprooflabs/convert/releases/tag/0.0.4)). 

After I got those in place, it seems trivial to switch this project over to Postgres 17.

## Output from `make`

Test output reports zero issues.


```bash
.
----------------------------------------------------------------------
Ran 49 tests in 2.060s

OK
docker exec -it \
	-e POSTGRES_PASSWORD=mysecretpassword \
	-e POSTGRES_USER=postgres \
	-u 1000:1000 \
	pgosm /bin/bash -c "cd docker && coverage report -m ./*.py"
Name                            Stmts   Miss  Cover   Missing
-------------------------------------------------------------
./db.py                           306    199    35%   85-87, 93-95, 121-122, 146-173, 185-195, 201-209, 226-252, 277-302, 328-330, 348-356, 372-386, 402-417, 430-431, 450-461, 478-481, 496-513, 525-561, 571-576, 590-610, 622-645, 657-661, 675-693, 724
./geofabrik.py                    109     76    30%   47-73, 85-107, 131-143, 146-148, 173, 188-202, 226-234, 251-262, 274-281
./helpers.py                      168     20    88%   67, 74-75, 144-145, 212-213, 219-226, 335-342, 352
./osm2pgsql_recommendation.py      23      8    65%   33-48
./pgosm_flex.py                   257    153    40%   82-195, 219-253, 269-291, 330, 412, 428-440, 457-471, 531-550, 563-570, 580-595, 606-623, 627-628
./qgis_styles.py                   48     38    21%   22-28, 39-49, 62-71, 82-100, 110-125
-------------------------------------------------------------
TOTAL                             911    494    46%
# Data import tests
docker cp tests \
	pgosm:/app/tests
Successfully copied 28.5MB to pgosm:/app/tests
docker exec -it pgosm \
	chown 1000:1000 /app/tests/
# Errors when running under docker are saved in
#  /app/tests/tmp/<test_with_error>.diff
docker exec -it \
	-e POSTGRES_PASSWORD=mysecretpassword \
	-e POSTGRES_USER=postgres \
	-u 1000:1000 \
	pgosm /bin/bash -c "cd tests && ./run-output-tests.sh"
Running PgOSM-Flex test queries
Data output tests completed successfully.

real	1m28.951s
user	0m0.377s
sys	0m0.305s
```