### PR TITLE
Bump to Postgres 18 and PostGIS 3.6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM postgis/postgis:17-3.5
+# 18-3.6 is Debian Trixie (13)
+FROM postgis/postgis:18-3.6
 
 LABEL maintainer="PgOSM Flex - https://github.com/rustprooflabs/pgosm-flex"
 
@@ -15,10 +16,10 @@ RUN apt-get update \
         libboost-dev libboost-system-dev \
         libboost-filesystem-dev libexpat1-dev zlib1g-dev \
         libbz2-dev libpq-dev libproj-dev lua5.4 liblua5.4-dev \
-        python3 python3-distutils \
-        postgresql-server-dev-17 \
+        python3 python3.13-venv \
+        postgresql-server-dev-18 \
         curl unzip \
-        postgresql-17-pgrouting \
+        postgresql-18-pgrouting \
         nlohmann-json3-dev \
         osmium-tool \
     && rm -rf /var/lib/apt/lists/*
@@ -28,8 +29,11 @@ RUN wget https://luarocks.org/releases/luarocks-3.9.2.tar.gz \
     && cd luarocks-3.9.2 \
     && ./configure && make && make install
 
+RUN python3 -m venv /venv 
+ENV PATH="/venv/bin:$PATH"
+
 RUN curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py \
-    && python3 /tmp/get-pip.py \
+    && python /tmp/get-pip.py \
     && rm /tmp/get-pip.py
 
 RUN luarocks install inifile
@@ -51,12 +55,12 @@ RUN git clone --depth 1 --branch $OSM2PGSQL_BRANCH $OSM2PGSQL_REPO \
     && apt autoremove -y \
     && cd /tmp && rm -r /tmp/osm2pgsql
 
-RUN wget https://github.com/rustprooflabs/pgdd/releases/download/0.6.0/pgdd_0.6.0_postgis_pg17_amd64.deb \
-    && dpkg -i ./pgdd_0.6.0_postgis_pg17_amd64.deb \
-    && rm ./pgdd_0.6.0_postgis_pg17_amd64.deb \
-    && wget https://github.com/rustprooflabs/convert/releases/download/0.0.4/convert_0.0.4_postgis_pg17_amd64.deb \
-    && dpkg -i ./convert_0.0.4_postgis_pg17_amd64.deb \
-    && rm ./convert_0.0.4_postgis_pg17_amd64.deb
+RUN wget https://github.com/rustprooflabs/pgdd/releases/download/0.6.1/pgdd_0.6.1_postgis_pg18_amd64.deb \
+    && dpkg -i ./pgdd_0.6.1_postgis_pg18_amd64.deb \
+    && rm ./pgdd_0.6.1_postgis_pg18_amd64.deb \
+    && wget https://github.com/rustprooflabs/convert/releases/download/0.0.5/convert_0.0.5_postgis_pg18_amd64.deb \
+    && dpkg -i ./convert_0.0.5_postgis_pg18_amd64.deb \
+    && rm ./convert_0.0.5_postgis_pg18_amd64.deb
 
 
 


### PR DESCRIPTION
* Bumps Docker image to Postgres 18 + PostGIS 3.6
* Bumps `osm2pgsql` to [version 2.2.0 ](https://github.com/osm2pgsql-dev/osm2pgsql/releases/tag/2.2.0)
* OS changes from Debian 11 to Debian 13 (Trixie)
