### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -1,5 +1,7 @@
 # Based on https://github.com/rust-lang/mdBook/wiki/Automated-Deployment%3A-GitHub-Actions
 name: Deploy mdbook
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rustprooflabs/pgosm-flex/security/code-scanning/13](https://github.com/rustprooflabs/pgosm-flex/security/code-scanning/13)

To fix the problem, add a `permissions` key to the workflow file. Because the workflow requires write access to repository contents (to push the built mdbook to the `gh-pages` branch), set `permissions: contents: write` at the root of the workflow file. This restricts the GITHUB_TOKEN to only write contents, and does not grant any additional (possibly unnecessary) write permissions to, e.g., issues or pull requests. It is best to place this block after the `name:` line and before or after the `on:` block for visibility and clarity. Only .github/workflows/deploy-book.yml needs to be changed; no other imports or method changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
