### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,6 @@
 name: Publish PgOSM-Flex Docker image
+permissions:
+  contents: read
 on:
   push:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/rustprooflabs/pgosm-flex/security/code-scanning/12](https://github.com/rustprooflabs/pgosm-flex/security/code-scanning/12)

**General fix:**  
Add a `permissions` key to the workflow, either at the root workflow level or at the job level, setting `contents: read` to enforce least privilege.

**Best way to fix:**  
Since there is only one job, you can add the `permissions: contents: read` key at the root level, just after the workflow name and before (or after) the `on:` key. This ensures all jobs inherit this restrictive permission. Alternatively, for workflows with multiple jobs (or more granular control), place `permissions` under each job as needed. In this case, root is sufficient.

**What to change:**  
- Edit `.github/workflows/docker-build.yml`.
- Insert the following as line 2 (after the `name:` line and before `on:`):
  ```yaml
  permissions:
    contents: read
  ```
- No other lines or files need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
